### PR TITLE
Integrating the scheme registration subsystem

### DIFF
--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -299,7 +299,7 @@ NO_NETLOC_SCHEMES = set(['urn', 'about', 'bitcoin', 'blob', 'data', 'geo',
 # As of Mar 11, 2017, there were 44 netloc schemes, and 13 non-netloc
 
 
-def register_scheme(text, uses_netloc=None, default_port=None):
+def register_scheme(text, uses_netloc=True, default_port=None):
     """Registers new scheme information, resulting in correct port and
     slash behavior from the URL object. There are dozens of standard
     schemes preregistered, so this function is mostly meant for
@@ -311,11 +311,13 @@ def register_scheme(text, uses_netloc=None, default_port=None):
         text (str): Text representing the scheme.
            (the 'http' in 'http://hatnote.com')
         uses_netloc (bool): Does the scheme support specifying a
-           network host? For instance, "http" does, "mailto" does not.
+           network host? For instance, "http" does, "mailto" does
+           not. Defaults to True.
         default_port (int): The default port, if any, for netloc-using
            schemes.
 
     .. _file an issue: https://github.com/mahmoud/hyperlink/issues
+
     """
     text = text.lower()
     if default_port is not None:
@@ -332,8 +334,8 @@ def register_scheme(text, uses_netloc=None, default_port=None):
             raise ValueError('unexpected default port while specifying'
                              ' non-netloc scheme: %r' % default_port)
         NO_NETLOC_SCHEMES.add(text)
-    elif uses_netloc is not None:
-        raise ValueError('uses_netloc expected True, False, or None')
+    else:
+        raise ValueError('uses_netloc expected bool, not: %r' % uses_netloc)
 
     return
 

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -321,7 +321,7 @@ def register_scheme(text, uses_netloc=None, default_port=None):
     if default_port is not None:
         try:
             default_port = int(default_port)
-        except ValueError:
+        except (ValueError, TypeError):
             raise ValueError('default_port expected integer or None, not %r'
                              % (default_port,))
 

--- a/hyperlink/test/common.py
+++ b/hyperlink/test/common.py
@@ -1,0 +1,70 @@
+
+
+from unittest import TestCase
+
+
+class HyperlinkTestCase(TestCase):
+    """This type mostly exists to provide a backwards-compatible
+    assertRaises method for Python 2.6 testing.
+    """
+    def assertRaises(self, excClass, callableObj=None, *args, **kwargs):
+        """Fail unless an exception of class excClass is raised
+           by callableObj when invoked with arguments args and keyword
+           arguments kwargs. If a different type of exception is
+           raised, it will not be caught, and the test case will be
+           deemed to have suffered an error, exactly as for an
+           unexpected exception.
+
+           If called with callableObj omitted or None, will return a
+           context object used like this::
+
+                with self.assertRaises(SomeException):
+                    do_something()
+
+           The context manager keeps a reference to the exception as
+           the 'exception' attribute. This allows you to inspect the
+           exception after the assertion::
+
+               with self.assertRaises(SomeException) as cm:
+                   do_something()
+               the_exception = cm.exception
+               self.assertEqual(the_exception.error_code, 3)
+        """
+        context = _AssertRaisesContext(excClass, self)
+        if callableObj is None:
+            return context
+        with context:
+            callableObj(*args, **kwargs)
+
+
+class _AssertRaisesContext(object):
+    "A context manager used to implement HyperlinkTestCase.assertRaises."
+
+    def __init__(self, expected, test_case, expected_regexp=None):
+        self.expected = expected
+        self.failureException = test_case.failureException
+        self.expected_regexp = expected_regexp
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_type is None:
+            try:
+                exc_name = self.expected.__name__
+            except AttributeError:
+                exc_name = str(self.expected)
+            raise self.failureException("%s not raised" % exc_name)
+        if not issubclass(exc_type, self.expected):
+            # let unexpected exceptions pass through
+            return False
+        self.exception = exc_value  # store for later retrieval
+        if self.expected_regexp is None:
+            return True
+
+        expected_regexp = self.expected_regexp
+        exc_str = str(exc_value)
+        if not expected_regexp.search(exc_str):
+            raise self.failureException('%r does not match %r' %
+                                        (expected_regexp.pattern, exc_str))
+        return True

--- a/hyperlink/test/common.py
+++ b/hyperlink/test/common.py
@@ -40,31 +40,19 @@ class HyperlinkTestCase(TestCase):
 class _AssertRaisesContext(object):
     "A context manager used to implement HyperlinkTestCase.assertRaises."
 
-    def __init__(self, expected, test_case, expected_regexp=None):
+    def __init__(self, expected, test_case):
         self.expected = expected
         self.failureException = test_case.failureException
-        self.expected_regexp = expected_regexp
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
         if exc_type is None:
-            try:
-                exc_name = self.expected.__name__
-            except AttributeError:
-                exc_name = str(self.expected)
-            raise self.failureException("%s not raised" % exc_name)
+            exc_name = self.expected.__name__
+            raise self.failureException("%s not raised" % (exc_name,))
         if not issubclass(exc_type, self.expected):
             # let unexpected exceptions pass through
             return False
         self.exception = exc_value  # store for later retrieval
-        if self.expected_regexp is None:
-            return True
-
-        expected_regexp = self.expected_regexp
-        exc_str = str(exc_value)
-        if not expected_regexp.search(exc_str):
-            raise self.failureException('%r does not match %r' %
-                                        (expected_regexp.pattern, exc_str))
         return True

--- a/hyperlink/test/test_common.py
+++ b/hyperlink/test/test_common.py
@@ -1,0 +1,106 @@
+"""
+Tests for hyperlink.test.common
+"""
+from unittest import TestCase
+from .common import HyperlinkTestCase
+
+
+class _ExpectedException(Exception):
+    """An exception used to test HyperlinkTestCase.assertRaises.
+
+    """
+
+
+class _UnexpectedException(Exception):
+    """An exception used to test HyperlinkTestCase.assertRaises.
+
+    """
+
+
+class TestHyperlink(TestCase):
+    """Tests for HyperlinkTestCase"""
+
+    def setUp(self):
+        self.hyperlink_test = HyperlinkTestCase("run")
+
+    def test_assertRaisesWithCallable(self):
+        """HyperlinkTestCase.assertRaises does not raise an AssertionError
+        when given a callable that, when called with the provided
+        arguments, raises the expected exception.
+
+        """
+        called_with = []
+
+        def raisesExpected(*args, **kwargs):
+            called_with.append((args, kwargs))
+            raise _ExpectedException
+
+        self.hyperlink_test.assertRaises(_ExpectedException,
+                                         raisesExpected, 1, keyword=True)
+        self.assertEqual(called_with, [((1,), {"keyword": True})])
+
+    def test_assertRaisesWithCallableUnexpectedException(self):
+        """When given a callable that raises an unexpected exception,
+        HyperlinkTestCase.assertRaises raises that exception.
+
+        """
+
+        def doesNotRaiseExpected(*args, **kwargs):
+            raise _UnexpectedException
+
+        try:
+            self.hyperlink_test.assertRaises(_ExpectedException,
+                                             doesNotRaiseExpected)
+        except _UnexpectedException:
+            pass
+
+    def test_assertRaisesWithCallableDoesNotRaise(self):
+        """HyperlinkTestCase.assertRaises raises an AssertionError when given
+        a callable that, when called, does not raise any exception.x
+
+        """
+
+        def doesNotRaise(*args, **kwargs):
+            return True
+
+        try:
+            self.hyperlink_test.assertRaises(_ExpectedException,
+                                             doesNotRaise)
+        except AssertionError:
+            pass
+
+    def test_assertRaisesContextManager(self):
+        """HyperlinkTestCase.assertRaises does not raise an AssertionError
+        when used as a context manager with a suite that raises the
+        expected exception.  The context manager stores the exception
+        instance under its `exception` instance variable.
+
+        """
+        with self.hyperlink_test.assertRaises(_ExpectedException) as cm:
+            raise _ExpectedException
+
+        self.assertTrue(isinstance(cm.exception, _ExpectedException))
+
+    def test_assertRaisesContextManagerUnexpectedException(self):
+        """When used as a context manager with a block that raises an
+        unexpected exception, HyperlinkTestCase.assertRaises raises
+        that unexpected exception.
+
+        """
+        try:
+            with self.hyperlink_test.assertRaises(_ExpectedException):
+                raise _UnexpectedException
+        except _UnexpectedException:
+            pass
+
+    def test_assertRaisesContextManagerDoesNotRaise(self):
+        """HyperlinkTestcase.assertRaises raises an AssertionError when used
+        as a context manager with a block that does not raise any
+        exception.
+
+        """
+        try:
+            with self.hyperlink_test.assertRaises(_ExpectedException):
+                pass
+        except AssertionError:
+            pass

--- a/hyperlink/test/test_common.py
+++ b/hyperlink/test/test_common.py
@@ -56,7 +56,7 @@ class TestHyperlink(TestCase):
 
     def test_assertRaisesWithCallableDoesNotRaise(self):
         """HyperlinkTestCase.assertRaises raises an AssertionError when given
-        a callable that, when called, does not raise any exception.x
+        a callable that, when called, does not raise any exception.
 
         """
 

--- a/hyperlink/test/test_scheme_registration.py
+++ b/hyperlink/test/test_scheme_registration.py
@@ -26,6 +26,14 @@ class TestSchemeRegistration(HyperlinkTestCase):
         assert u3.to_text() == 'deltron://example.com'
 
         register_scheme('nonetron', default_port=3031)
+        u4 = URL(scheme='nonetron')
+        u4 = u4.replace(host='example.com')
+        assert u4.to_text() == 'nonetron://example.com'
+
+        register_scheme('noloctron', uses_netloc=False)
+        u4 = URL(scheme='noloctron')
+        u4 = u4.replace(path=("example", "path"))
+        assert u4.to_text() == 'noloctron:example/path'
 
     def test_register_no_netloc_scheme(self):
         register_scheme('netlocless', uses_netloc=False)

--- a/hyperlink/test/test_scheme_registration.py
+++ b/hyperlink/test/test_scheme_registration.py
@@ -49,6 +49,12 @@ class TestSchemeRegistration(HyperlinkTestCase):
         with self.assertRaises(ValueError):
             register_scheme('badnetlocless', uses_netloc=False, default_port=7)
 
+    def test_invalid_uses_netloc(self):
+        with self.assertRaises(ValueError):
+            register_scheme('badnetloc', uses_netloc=None)
+        with self.assertRaises(ValueError):
+            register_scheme('badnetloc', uses_netloc=object())
+
     def test_register_invalid_uses_netloc(self):
         with self.assertRaises(ValueError):
             register_scheme('lol', uses_netloc=lambda: 'nope')

--- a/hyperlink/test/test_scheme_registration.py
+++ b/hyperlink/test/test_scheme_registration.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+
+from .common import HyperlinkTestCase
+from .._url import register_scheme, URL
+
+
+class TestSchemeRegistration(HyperlinkTestCase):
+
+    def test_register_scheme_basic(self):
+        register_scheme('deltron', uses_netloc=True, default_port=3030)
+
+        u1 = URL.from_text('deltron://example.com')
+        assert u1.scheme == 'deltron'
+        assert u1.port == 3030
+        assert u1.uses_netloc is True
+
+        # test netloc works even when the original gives no indication
+        u2 = URL.from_text('deltron:')
+        u2 = u2.replace(host='example.com')
+        assert u2.to_text() == 'deltron://example.com'
+
+        # test default port means no emission
+        u3 = URL.from_text('deltron://example.com:3030')
+        assert u3.to_text() == 'deltron://example.com'
+
+        register_scheme('nonetron', default_port=3031)
+
+    def test_register_no_netloc_scheme(self):
+        register_scheme('netlocless', uses_netloc=False)
+
+    def test_register_no_netloc_with_port(self):
+        with self.assertRaises(ValueError):
+            register_scheme('badnetlocless', uses_netloc=False, default_port=7)
+
+    def test_register_invalid_uses_netloc(self):
+        with self.assertRaises(ValueError):
+            register_scheme('lol', uses_netloc=lambda: 'nope')
+
+    def test_register_invalid_port(self):
+        with self.assertRaises(ValueError):
+            register_scheme('nope', default_port=lambda: 'lol')

--- a/hyperlink/test/test_scheme_registration.py
+++ b/hyperlink/test/test_scheme_registration.py
@@ -2,11 +2,20 @@
 from __future__ import unicode_literals
 
 
+from .. import _url
 from .common import HyperlinkTestCase
 from .._url import register_scheme, URL
 
 
 class TestSchemeRegistration(HyperlinkTestCase):
+
+    def setUp(self):
+        self._orig_scheme_port_map = dict(_url.SCHEME_PORT_MAP)
+        self._orig_no_netloc_schemes = set(_url.NO_NETLOC_SCHEMES)
+
+    def tearDown(self):
+        _url.SCHEME_PORT_MAP = self._orig_scheme_port_map
+        _url.NO_NETLOC_SCHEMES = self._orig_no_netloc_schemes
 
     def test_register_scheme_basic(self):
         register_scheme('deltron', uses_netloc=True, default_port=3030)
@@ -30,13 +39,11 @@ class TestSchemeRegistration(HyperlinkTestCase):
         u4 = u4.replace(host='example.com')
         assert u4.to_text() == 'nonetron://example.com'
 
+    def test_register_no_netloc_scheme(self):
         register_scheme('noloctron', uses_netloc=False)
         u4 = URL(scheme='noloctron')
         u4 = u4.replace(path=("example", "path"))
         assert u4.to_text() == 'noloctron:example/path'
-
-    def test_register_no_netloc_scheme(self):
-        register_scheme('netlocless', uses_netloc=False)
 
     def test_register_no_netloc_with_port(self):
         with self.assertRaises(ValueError):

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -6,8 +6,8 @@
 from __future__ import unicode_literals
 
 import socket
-from unittest import TestCase
 
+from .common import HyperlinkTestCase
 from .. import URL, URLParseError
 # automatically import the py27 windows implementation when appropriate
 from .._url import inet_pton, SCHEME_PORT_MAP
@@ -118,7 +118,7 @@ ROUNDTRIP_TESTS = (
 )
 
 
-class TestURL(TestCase):
+class TestURL(HyperlinkTestCase):
     """
     Tests for L{URL}.
     """
@@ -1020,69 +1020,3 @@ class TestURL(TestCase):
         u2 = URL.from_text('http://example.com/')
 
         assert u1 == u2
-
-
-    # python 2.6 compat
-    def assertRaises(self, excClass, callableObj=None, *args, **kwargs):
-        """Fail unless an exception of class excClass is raised
-           by callableObj when invoked with arguments args and keyword
-           arguments kwargs. If a different type of exception is
-           raised, it will not be caught, and the test case will be
-           deemed to have suffered an error, exactly as for an
-           unexpected exception.
-
-           If called with callableObj omitted or None, will return a
-           context object used like this::
-
-                with self.assertRaises(SomeException):
-                    do_something()
-
-           The context manager keeps a reference to the exception as
-           the 'exception' attribute. This allows you to inspect the
-           exception after the assertion::
-
-               with self.assertRaises(SomeException) as cm:
-                   do_something()
-               the_exception = cm.exception
-               self.assertEqual(the_exception.error_code, 3)
-        """
-        context = _AssertRaisesContext(excClass, self)
-        if callableObj is None:
-            return context
-        with context:
-            callableObj(*args, **kwargs)
-
-
-# PYTHON 2.6 compat
-
-class _AssertRaisesContext(object):
-    """A context manager used to implement TestCase.assertRaises* methods."""
-
-    def __init__(self, expected, test_case, expected_regexp=None):
-        self.expected = expected
-        self.failureException = test_case.failureException
-        self.expected_regexp = expected_regexp
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, tb):
-        if exc_type is None:
-            try:
-                exc_name = self.expected.__name__
-            except AttributeError:
-                exc_name = str(self.expected)
-            raise self.failureException(
-                "{0} not raised".format(exc_name))
-        if not issubclass(exc_type, self.expected):
-            # let unexpected exceptions pass through
-            return False
-        self.exception = exc_value # store for later retrieval
-        if self.expected_regexp is None:
-            return True
-
-        expected_regexp = self.expected_regexp
-        if not expected_regexp.search(str(exc_value)):
-            raise self.failureException('"%s" does not match "%s"' %
-                     (expected_regexp.pattern, str(exc_value)))
-        return True

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 
 __author__ = 'Mahmoud Hashemi and Glyph Lefkowitz'
-__version__ = '17.2.1'
+__version__ = '17.2.2dev'
 __contact__ = 'mahmoud@hatnote.com'
 __url__ = 'https://github.com/python-hyper/hyperlink'
 __license__ = 'BSD'

--- a/tox.ini
+++ b/tox.ini
@@ -13,3 +13,4 @@ changedir = .tox
 deps = coverage
 commands = coverage combine --rcfile {toxinidir}/.tox-coveragerc
            coverage report --rcfile {toxinidir}/.tox-coveragerc
+           coverage html --rcfile {toxinidir}/.tox-coveragerc -d {toxinidir}/htmlcov


### PR DESCRIPTION
This PR covers hyperlink's method for handling of schemes without default support. 

As you may know, the URL scheme (e.g., http/ssh/mailto/etc.) controls some pretty important semantics for later parts of the URL. I've tried to make the list of built-in schemes as complete as possible, with ~60 schemes supported by default. 

That said, the list is always growing, and I didn't want to make the same mistake as the standard library's urlparse, by hardcoding several lists without some developer recourse.

Even though this PR only adds tests, I'd be very happy to get any feedback on the system as a whole.