### PR TITLE
Fix percent decoding and normalization

### DIFF
--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -819,7 +819,8 @@ class URL(object):
         return bool(self.scheme and self.host)
 
     def replace(self, scheme=_UNSET, host=_UNSET, path=_UNSET, query=_UNSET,
-                fragment=_UNSET, port=_UNSET, rooted=_UNSET, userinfo=_UNSET):
+                fragment=_UNSET, port=_UNSET, rooted=_UNSET, userinfo=_UNSET,
+                family=_UNSET, uses_netloc=_UNSET):
         """:class:`URL` objects are immutable, which means that attributes
         are designed to be set only once, at construction. Instead of
         modifying an existing URL, one simply creates a copy with the
@@ -861,6 +862,8 @@ class URL(object):
             port=_optional(port, self.port),
             rooted=_optional(rooted, self.rooted),
             userinfo=_optional(userinfo, self.userinfo),
+            family=_optional(family, self.family),
+            uses_netloc=_optional(uses_netloc, self.uses_netloc)
         )
 
     @classmethod

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -451,36 +451,22 @@ def _percent_decode(text, _decode_map=_HEX_CHAR_MAP):
     :func:`_decode_path_part`, as every percent-encodable part of the
     URL has characters which should not be percent decoded.
 
+    >>> _percent_decode(u'abc%20def')
+    u'abc def'
+
     Args:
        text (unicode): The ASCII text with percent-encoding present.
 
     Returns:
        unicode: The percent-decoded version of *text*, with UTF-8
          decoding applied.
-
     """
     try:
-        quotedBytes = text.encode("ascii")
+        quoted_bytes = text.encode("ascii")
     except UnicodeEncodeError:
         return text
-    unquotedBytes = _unquote_to_bytes(quotedBytes, _decode_map=_decode_map)
-    try:
-        return unquotedBytes.decode("utf-8")
-    except UnicodeDecodeError:
-        return text
 
-
-def _unquote_to_bytes(text, _decode_map=_HEX_CHAR_MAP):
-    """unquote_to_bytes('abc%20def') -> b'abc def'."""
-    # Note: strings are encoded as UTF-8. This is only an issue if it contains
-    # unescaped non-ASCII characters, which URIs should not.
-    if not text:
-        # Is it a string-like object?
-        text.split
-        return b''
-    if isinstance(text, unicode):
-        text = text.encode('utf-8')
-    bits = text.split(b'%')
+    bits = quoted_bytes.split(b'%')
     if len(bits) == 1:
         return text
 
@@ -494,7 +480,13 @@ def _unquote_to_bytes(text, _decode_map=_HEX_CHAR_MAP):
         except KeyError:
             append(b'%')
             append(item)
-    return b''.join(res)
+
+    unquoted_bytes = b''.join(res)
+
+    try:
+        return unquoted_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return text
 
 
 def _resolve_dot_segments(path):

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -941,6 +941,13 @@ class TestURL(HyperlinkTestCase):
         url2 = url.replace(scheme='mailto')
         self.assertEquals(url2.to_text(), 'mailto:/path/to/heck')
 
+        url_text = 'unregisteredscheme:///a/b/c'
+        url = URL.from_text(url_text)
+        no_netloc_url = url.replace(uses_netloc=False)
+        self.assertEquals(no_netloc_url.to_text(), 'unregisteredscheme:/a/b/c')
+        netloc_url = url.replace(uses_netloc=True)
+        self.assertEquals(netloc_url.to_text(), url_text)
+
         return
 
     def test_wrong_constructor(self):

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -115,6 +115,27 @@ ROUNDTRIP_TESTS = (
      '20Linux%20precise-5.7.1.iso&tr=udp://tracker.openbittorrent.com:80&'
      'tr=udp://tracker.publicbt.com:80&tr=udp://tracker.istole.it:6969&'
      'tr=udp://tracker.ccc.de:80&tr=udp://open.demonii.com:1337'),
+
+    # percent-encoded delimiters in percent-encodable fields
+
+    'https://%3A@example.com/',  # colon in username
+    'https://%40@example.com/',  # at sign in username
+    'https://%2f@example.com/',  # slash in username
+    'https://a:%3a@example.com/',  # colon in password
+    'https://a:%40@example.com/',  # at sign in password
+    'https://a:%2f@example.com/',  # slash in password
+    'https://a:%3f@example.com/',  # question mark in password
+    'https://example.com/%2F/',  # slash in path
+    'https://example.com/%3F/',  # question mark in path
+    'https://example.com/%23/',  # hash in path
+    'https://example.com/?%23=b',  # hash in query param name
+    'https://example.com/?%3D=b',  # equals in query param name
+    'https://example.com/?%26=b',  # ampersand in query param name
+    'https://example.com/?a=%23',  # hash in query param value
+    'https://example.com/?a=%26',  # ampersand in query param value
+    'https://example.com/?a=%3D',  # equals in query param value
+    # double-encoded percent sign in all percent-encodable positions:
+    "http://(%2525):(%2525)@example.com/(%2525)/?(%2525)=(%2525)#(%2525)",
 )
 
 
@@ -231,15 +252,18 @@ class TestURL(HyperlinkTestCase):
         L{URL.to_text} should invert L{URL.from_text}.
         """
         for test in ROUNDTRIP_TESTS:
-            result = URL.from_text(test).to_text()
+            result = URL.from_text(test).to_text(with_password=True)
             self.assertEqual(test, result)
 
-    def test_roundtrip_iri(self):
+    def test_roundtrip_double_iri(self):
         for test in ROUNDTRIP_TESTS:
             url = URL.from_text(test)
             iri = url.to_iri()
-            assert iri == url.to_iri()
-            assert iri.to_text() == url.to_iri().to_text()
+            double_iri = iri.to_iri()
+            assert iri == double_iri
+            iri_text = iri.to_text(with_password=True)
+            double_iri_text = double_iri.to_text(with_password=True)
+            assert iri_text == double_iri_text
         return
 
     def test_equality(self):

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -234,6 +234,14 @@ class TestURL(HyperlinkTestCase):
             result = URL.from_text(test).to_text()
             self.assertEqual(test, result)
 
+    def test_roundtrip_iri(self):
+        for test in ROUNDTRIP_TESTS:
+            url = URL.from_text(test)
+            iri = url.to_iri()
+            assert iri == url.to_iri()
+            assert iri.to_text() == url.to_iri().to_text()
+        return
+
     def test_equality(self):
         """
         Two URLs decoded using L{URL.from_text} will be equal (C{==}) if they

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -136,6 +136,8 @@ ROUNDTRIP_TESTS = (
     'https://example.com/?a=%3D',  # equals in query param value
     # double-encoded percent sign in all percent-encodable positions:
     "http://(%2525):(%2525)@example.com/(%2525)/?(%2525)=(%2525)#(%2525)",
+    # colon in first part of schemeless relative url
+    'first_seg_rel_path__colon%3Anotok/second_seg__colon%3Aok',
 )
 
 
@@ -261,6 +263,7 @@ class TestURL(HyperlinkTestCase):
             iri = url.to_iri()
             double_iri = iri.to_iri()
             assert iri == double_iri
+
             iri_text = iri.to_text(with_password=True)
             double_iri_text = double_iri.to_text(with_password=True)
             assert iri_text == double_iri_text
@@ -277,7 +280,7 @@ class TestURL(HyperlinkTestCase):
         self.assertNotEqual(
             urlpath,
             URL.from_text('ftp://www.anotherinvaliddomain.com/'
-                         'foo/bar/baz/?zot=21&zut')
+                          'foo/bar/baz/?zot=21&zut')
         )
 
     def test_fragmentEquality(self):


### PR DESCRIPTION
Per #16, hyperlink's inherited behavior was applying percent-decoding too broadly. Each percent-encodable field in the URL (userinfo, path, query string, and fragment), has certain special characters that should *never* be decoded [1].

To this end, this PR adds and utilizes a `_decode_XXX_part()` function for each of the fields, symmetrical to the `_encode_XXX_part()` that was already there.

Several test cases were added, as well as a general test for the invariant that multiple calls of `to_iri()` will not generate different URL objects.

@glyph has shown the most interest in this feature, so I've added him as reviewer.

[1]: To take the path as an example, the special characters include delimiters, such as the slash (`/`), question mark (`?`), and hash mark (`#`), as well as the percent sign (`%`) itself.
