### PR TITLE
Simplify the hex formatting in _url.py

### DIFF
--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -157,7 +157,7 @@ def _make_decode_map(delims, allow_percent=False):
     if not allow_percent:
         delims = set(delims) | set([u'%'])
     for delim in delims:
-        _hexord = hex(ord(delim))[2:].zfill(2).encode('ascii').upper()
+        _hexord = '{0:02X}'.format(ord(delim)).encode('ascii')
         _hexord_lower = _hexord.lower()
         ret.pop(_hexord)
         if _hexord != _hexord_lower:


### PR DESCRIPTION
Following up on my suggestion in #23. Makes this line a little more readable, and consistent with line 177:

```python
ret[c] = ret[v] = '%{0:02X}'.format(i)
```

Informal testing with `timeit` is inconclusive, suggesting they’re about the same time.