### PR TITLE
Add URL.normalize()

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,13 +6,18 @@
 * Get coverage up
 * Switch off ctypes/socket for IP validation
 * rebase method for path (prepends to path)
+* switch default percent encoding to upper case (a la RFC 3986 2.1)
 
 ## normalize method
 
 * unquote all unreserved characters (RFC 3986 2.3)
 * lowercase scheme
-* lowercase host
+* lowercase host (including lowercase ipv6 addresses)
 * resolve path parts (RFC 3986 6.2.2)
+* percent encoding (RFC 3986 2.1) to uppercase (add a
+  `normalize_case=False` to `_percent_decode`, with appropriate upward
+  propagation)
+
 
 ## Complete
 

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1005,8 +1005,11 @@ class URL(object):
         if host:
             kw['host'] = self.host.lower()
         if path:
-            kw['path'] = [_decode_unreserved(p) for p in
-                          _resolve_dot_segments(self.path)]
+            if self.path:
+                kw['path'] = [_decode_unreserved(p) for p in
+                              _resolve_dot_segments(self.path)]
+            else:
+                kw['path'] = (u'',)
         if query:
             kw['query'] = [(_decode_unreserved(k), _decode_unreserved(v))
                            for k, v in self.query]

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1000,6 +1000,7 @@ class URL(object):
         .. _Section 6.2.2 of RFC 3986: https://tools.ietf.org/html/rfc3986#section-6.2.2
         """
         # TODO: userinfo?
+        # TODO: uppercase percent (3986 2.1)
         kw = {}
         if scheme:
             kw['scheme'] = self.scheme.lower()

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1026,7 +1026,7 @@ class URL(object):
         * Decode unreserved characters (`RFC 3986 2.3`_)
         * Uppercase remaining percent-encoded octets (`RFC 3986 2.1`_)
         * Convert scheme and host casing to lowercase (`RFC 3986 3.2.2`_)
-        * Resolve any "." and ".." references in the path (`RFC 3986 6.2.2`_)
+        * Resolve any "." and ".." references in the path (`RFC 3986 6.2.2.3`_)
         * Ensure an ending slash on URLs with an empty path (`RFC 3986 6.2.3`_)
 
         All are applied by default, but normalizations can be disabled
@@ -1047,7 +1047,7 @@ class URL(object):
         .. _RFC 3986 3.2.2: https://tools.ietf.org/html/rfc3986#section-3.2.2
         .. _RFC 3986 2.3: https://tools.ietf.org/html/rfc3986#section-2.3
         .. _RFC 3986 2.1: https://tools.ietf.org/html/rfc3986#section-2.1
-        .. _RFC 3986 6.2.2: https://tools.ietf.org/html/rfc3986#section-6.2.2
+        .. _RFC 3986 6.2.2.3: https://tools.ietf.org/html/rfc3986#section-6.2.2.3
         .. _RFC 3986 6.2.3: https://tools.ietf.org/html/rfc3986#section-6.2.3
 
         """

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -196,7 +196,8 @@ _QUERY_DECODE_MAP = _make_decode_map(_QUERY_DELIMS)
 _FRAGMENT_QUOTE_MAP = _make_quote_map(_FRAGMENT_SAFE)
 _FRAGMENT_DECODE_MAP = _make_decode_map(_FRAGMENT_DELIMS)
 _UNRESERVED_DECODE_MAP = dict([(k, v) for k, v in _HEX_CHAR_MAP.items()
-                               if v in _UNRESERVED_CHARS])
+                               if v.decode('ascii', 'replace')
+                               in _UNRESERVED_CHARS])
 
 _ROOT_PATHS = frozenset(((), (u'',)))
 

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1040,6 +1040,10 @@ class URL(object):
            query (bool): Normalize the query string
            fragment (bool): Normalize the fragment
 
+        >>> url = URL.from_text(u'Http://example.COM/a/../b/./c%2f?%61')
+        >>> print(url.normalize().to_text())
+        http://example.com/b/c%2F?a
+
         .. _RFC 3986 3.2.2: https://tools.ietf.org/html/rfc3986#section-3.2.2
         .. _RFC 3986 2.3: https://tools.ietf.org/html/rfc3986#section-2.3
         .. _RFC 3986 2.1: https://tools.ietf.org/html/rfc3986#section-2.1
@@ -1061,8 +1065,8 @@ class URL(object):
                 kw['path'] = (u'',)
         if query:
             kw['query'] = [(_decode_unreserved(k, normalize_case=True),
-                            _decode_unreserved(v, normalize_case=True))
-                           for k, v in self.query]
+                            _decode_unreserved(v, normalize_case=True)
+                            if v else v) for k, v in self.query]
         if fragment:
             kw['fragment'] = _decode_unreserved(self.fragment,
                                                 normalize_case=True)

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -1123,6 +1123,6 @@ class TestURL(HyperlinkTestCase):
         assert noop_norm_url == url
 
         # test that empty paths get at least one slash
-        slashless_url = URL.from_text('http://example.io?k=v')
+        slashless_url = URL.from_text('http://example.io')
         slashful_url = slashless_url.normalize()
-        assert slashful_url.to_text() == 'http://example.io/?k=v'
+        assert slashful_url.to_text() == 'http://example.io/'

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -1107,6 +1107,7 @@ class TestURL(HyperlinkTestCase):
         assert url.get('B%62') == ['C%63']
         assert len(url.path) == 4
 
+        # test that most expected normalizations happen
         norm_url = url.normalize()
 
         assert norm_url.scheme == 'http'
@@ -1116,6 +1117,12 @@ class TestURL(HyperlinkTestCase):
         assert norm_url.fragment == 'Dd'
         assert norm_url.to_text() == 'http://example.com/Aa?Bb=Cc#Dd'
 
+        # test that flags work
         noop_norm_url = url.normalize(scheme=False, host=False,
                                       path=False, query=False, fragment=False)
         assert noop_norm_url == url
+
+        # test that empty paths get at least one slash
+        slashless_url = URL.from_text('http://example.io?k=v')
+        slashful_url = slashless_url.normalize()
+        assert slashful_url.to_text() == 'http://example.io/?k=v'

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -1126,3 +1126,8 @@ class TestURL(HyperlinkTestCase):
         slashless_url = URL.from_text('http://example.io')
         slashful_url = slashless_url.normalize()
         assert slashful_url.to_text() == 'http://example.io/'
+
+        # test case normalization for percent encoding
+        delimited_url = URL.from_text('/a%2fb/cd%3f?k%3d=v%23#test')
+        norm_delimited_url = delimited_url.normalize()
+        assert norm_delimited_url.to_text() == '/a%2Fb/cd%3F?k%3D=v%23#test'

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -1131,3 +1131,6 @@ class TestURL(HyperlinkTestCase):
         delimited_url = URL.from_text('/a%2fb/cd%3f?k%3d=v%23#test')
         norm_delimited_url = delimited_url.normalize()
         assert norm_delimited_url.to_text() == '/a%2Fb/cd%3F?k%3D=v%23#test'
+
+        # test invalid percent encoding during normalize
+        assert URL(path=('', '%te%sts')).normalize().to_text() == '/%te%sts'


### PR DESCRIPTION
This PR adds a `normalize` method to `URL`, codifying five key normalization behaviors documented in RFC 3986:

* Decode unreserved characters (`RFC 3986 2.3`)                        
* Uppercase remaining percent-encoded octets (`RFC 3986 2.1`)          
* Convert scheme and host casing to lowercase (`RFC 3986 3.2.2`)       
* Resolve any "." and ".." references in the path (`RFC 3986 6.2.2`)   
* Ensure an ending slash on URLs with an empty path (`RFC 3986 6.2.3`) 

Which looks something like:

```python
  >>> url = URL.from_text(u'Http://example.COM/a/../b/./c%2f?%61')         
  >>> url.normalize().to_text()
  u'http://example.com/b/c%2F?a'
```

This gives explicit control to users in a lot of gray areas where it wasn't clear whether we should be eager in enforcing these normal forms. Now, interested parties can explicitly normalize if they'd like. Reviews welcome!