### PR TITLE
URL.click() for URL objects

### DIFF
--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1049,9 +1049,15 @@ class URL(object):
 
         .. _RFC 3986 section 5: https://tools.ietf.org/html/rfc3986#section-5
         """
-        _textcheck("relative URL", href)
         if href:
-            clicked = URL.from_text(href)
+            if isinstance(href, URL):
+                clicked = href
+            else:
+                # TODO: This error message is not completely accurate,
+                # as URL objects are now also valid, but Twisted's
+                # test suite (wrongly) relies on this exact message.
+                _textcheck('relative URL', href)
+                clicked = URL.from_text(href)
             if clicked.absolute:
                 return clicked
         else:

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -388,9 +388,14 @@ class TestURL(HyperlinkTestCase):
         res = 'http://hatnote.com/a/c/d/'
         self.assertEqual(u.click('').to_text(), res)
 
-
         # test click default arg is same as empty string above
         self.assertEqual(u.click().to_text(), res)
+
+        # test click on a URL instance
+        u = URL.fromText('http://localhost/foo/?abc=def')
+        u2 = URL.from_text('bar')
+        u3 = u.click(u2)
+        self.assertEqual(u3.to_text(), 'http://localhost/foo/bar')
 
     def test_clickRFC3986(self):
         """


### PR DESCRIPTION
This PR makes URL.click work with URL objects, not just text, fixing #35.

There is one slightly outstanding issue, detailed in a `TODO` comment, which is that I need to remove the error message checks in Twisted's test suite. I haven't known anybody to depend on the byte-for-byte unchangingness of error messages as a public API, and in this case, it's restricting usability.