### PR TITLE
Allow unescaped equal signs in query parameter values

### DIFF
--- a/.tox-coveragerc
+++ b/.tox-coveragerc
@@ -3,6 +3,8 @@ branch = True
 source =
     hyperlink
     ../hyperlink
+omit =
+    */flycheck_*
 
 [paths]
 source =

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -532,10 +532,16 @@ class TestURL(HyperlinkTestCase):
         """
         u = URL.from_text('http://localhost/?=x=x=x')
         self.assertEqual(u.get(''), ['x=x=x'])
-        self.assertEqual(u.to_text(), 'http://localhost/?=x%3Dx%3Dx')
+        # TODO: see #38
+        # self.assertEqual(u.to_text(), 'http://localhost/?=x%3Dx%3Dx')
         u = URL.from_text('http://localhost/?foo=x=x=x&bar=y')
         self.assertEqual(u.query, (('foo', 'x=x=x'), ('bar', 'y')))
-        self.assertEqual(u.to_text(), 'http://localhost/?foo=x%3Dx%3Dx&bar=y')
+        # TODO: see #38
+        # self.assertEqual(u.to_text(), 'http://localhost/?foo=x%3Dx%3Dx&bar=y')
+
+        u = URL.from_text('https://example.com/?argument=3&argument=4&operator=%3D')
+        iri = u.to_iri()
+        self.assertEqual(iri.get('operator'), ['='])
 
     def test_empty(self):
         """

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -542,12 +542,10 @@ class TestURL(HyperlinkTestCase):
         """
         u = URL.from_text('http://localhost/?=x=x=x')
         self.assertEqual(u.get(''), ['x=x=x'])
-        # TODO: see #38
-        # self.assertEqual(u.to_text(), 'http://localhost/?=x%3Dx%3Dx')
+        self.assertEqual(u.to_text(), 'http://localhost/?=x=x=x')
         u = URL.from_text('http://localhost/?foo=x=x=x&bar=y')
         self.assertEqual(u.query, (('foo', 'x=x=x'), ('bar', 'y')))
-        # TODO: see #38
-        # self.assertEqual(u.to_text(), 'http://localhost/?foo=x%3Dx%3Dx&bar=y')
+        self.assertEqual(u.to_text(), 'http://localhost/?foo=x=x=x&bar=y')
 
         u = URL.from_text('https://example.com/?argument=3&argument=4&operator=%3D')
         iri = u.to_iri()

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -542,6 +542,8 @@ class TestURL(HyperlinkTestCase):
         u = URL.from_text('https://example.com/?argument=3&argument=4&operator=%3D')
         iri = u.to_iri()
         self.assertEqual(iri.get('operator'), ['='])
+        # assert that the equals is not unnecessarily escaped
+        self.assertEqual(iri.to_uri().get('operator'), ['='])
 
     def test_empty(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py26,py27,py34,py35,py36,pypy,coverage-report,packaging
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt
-commands = coverage run --parallel --omit 'flycheck__*' --rcfile {toxinidir}/.tox-coveragerc -m pytest --doctest-modules {envsitepackagesdir}/hyperlink {posargs}
+commands = coverage run --parallel --rcfile {toxinidir}/.tox-coveragerc -m pytest --doctest-modules {envsitepackagesdir}/hyperlink {posargs}
 
 # Uses default basepython otherwise reporting doesn't work on Travis where
 # Python 3.6 is only available in 3.6 jobs.


### PR DESCRIPTION
Specifically, allow unescaped equal signs in query parameter values. Values are terminated by ampersands (`&`) or the fragment (`#`) or the end of the URL. See #38 for more details.

This change requires changing [Twisted's tests](https://github.com/twisted/twisted/blob/02a3221ed72e3385546f9421401bf40e360bb9bb/src/twisted/python/test/test_url.py#L484-L490), which inherited the overzealous escaping of urllib.