### PR TITLE
Also accept dictionaries as ‘query=’ arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## dev (not yet released)
 
+* Also accept dictionaries as ‘query=’ arguments (see #50)
+
 ## 17.3.1
 
 *(August 19, 2017)*

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -92,6 +92,14 @@ by the query parameters, sometimes called "query arguments" or "GET
 parameters". Regardless of what you call them, they are encoded in
 the query string portion of the URL, and they are very powerful.
 
+In the simplest case, these query parameters can be provided as a
+dictionary:
+
+   >>> url = URL.from_text('http://example.com/')
+   >>> url = url.replace(query={'a': 'b', 'c': 'd'})
+   >>> url.to_text()
+   u'http://example.com/?a=b&c=d'
+
 Query parameters are actually a type of "multidict", where a given key
 can have multiple values. This is why the :meth:`~URL.get()` method
 returns a list of strings. Keys can also have no value, which is

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -742,10 +742,14 @@ class TestURL(HyperlinkTestCase):
     def test_queryIterable(self):
         """
         When a L{URL} is created with a C{query} argument, the C{query}
-        argument is converted into an N-tuple of 2-tuples.
+        argument is converted into an N-tuple of 2-tuples, sensibly
+        handling dictionaries.
         """
+        expected = (('alpha', 'beta'),)
         url = URL(query=[['alpha', 'beta']])
-        self.assertEqual(url.query, (('alpha', 'beta'),))
+        self.assertEqual(url.query, expected)
+        url = URL(query={'alpha': 'beta'})
+        self.assertEqual(url.query, expected)
 
     def test_pathIterable(self):
         """


### PR DESCRIPTION
The URL constructor and the `.replace()` method now sensibly handle
dictionaries passed to the ‘query’ argument, instead of strictly
requiring it to be an iterable of `(key, value)` pairs (both of which
must be strings).

Examples:

```
  URL(query={"foo": "bar"})
  url.replace(query={"foo": "bar"})
```

This simplifies the API for the common use case, in which:

- the order of the items does not matter
  (though Python >= 3.6 preserves dictionary order)
- no duplicate parameters are present

Updated the docs to include an example of this.

Fixes #50.