### PR TITLE
DecodedURL

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,8 @@
 * Get coverage up
 * Switch off ctypes/socket for IP validation
 * rebase method for path (prepends to path)
-* switch default percent encoding to upper case (a la RFC 3986 2.1)
 * sibling() should be maximal=False like child()
+* make subencoding an exposed parameter
 
 ## normalize method
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
 * Switch off ctypes/socket for IP validation
 * rebase method for path (prepends to path)
 * switch default percent encoding to upper case (a la RFC 3986 2.1)
+* sibling() should be maximal=False like child()
 
 ## normalize method
 

--- a/hyperlink/__init__.py
+++ b/hyperlink/__init__.py
@@ -1,10 +1,16 @@
 
-from ._url import URL, DecodedURL, URLParseError, register_scheme, parse_host
+from ._url import (URL,
+                   parse,
+                   EncodedURL,
+                   DecodedURL,
+                   URLParseError,
+                   register_scheme)
 
 __all__ = [
     "URL",
+    "parse",
+    "EncodedURL",
     "DecodedURL",
     "URLParseError",
     "register_scheme",
-    "parse_host"
 ]

--- a/hyperlink/__init__.py
+++ b/hyperlink/__init__.py
@@ -1,8 +1,9 @@
 
-from ._url import URL, URLParseError, register_scheme, parse_host
+from ._url import URL, DecodedURL, URLParseError, register_scheme, parse_host
 
 __all__ = [
     "URL",
+    "DecodedURL",
     "URLParseError",
     "register_scheme",
     "parse_host"

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1468,6 +1468,11 @@ class DecodedURL(object):
                       for x in (k, v))
                 for k, v in self._url.query]
 
+    @property
+    def userinfo(self):
+        return u':'.join([_percent_decode(p) for p in
+                          self._url.userinfo.split(':', 1)])
+
     def replace(self, scheme=_UNSET, host=_UNSET, path=_UNSET, query=_UNSET,
                 fragment=_UNSET, port=_UNSET, rooted=_UNSET, userinfo=_UNSET,
                 uses_netloc=_UNSET):
@@ -1480,7 +1485,7 @@ class DecodedURL(object):
                      for k, v in iter_pairs(query)]
         if userinfo is not _UNSET:
             userinfo = u':'.join([_encode_userinfo_part(p) for p in
-                                  self.userinfo.split(':', 1)])
+                                  userinfo.split(':', 1)])
         new_url = self._url.replace(scheme=scheme,
                                     host=host,
                                     path=path,

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1519,9 +1519,9 @@ class DecodedURL(object):
         return
 
     @classmethod
-    def from_text(cls, text):
+    def from_text(cls, text, lazy=False):
         _url = URL.from_text(text)
-        return cls(_url)
+        return cls(_url, lazy=lazy)
 
     @property
     def encoded_url(self):
@@ -1623,13 +1623,6 @@ class DecodedURL(object):
         return self.userinfo[0]
 
     @property
-    def password(self):
-        try:
-            return self.userinfo[1]
-        except IndexError:
-            return None
-
-    @property
     def uses_netloc(self):
         return self._url.uses_netloc
 
@@ -1711,8 +1704,8 @@ class DecodedURL(object):
     asIRI = to_iri
 
     @classmethod
-    def fromText(cls, s):
-        return cls.from_text(s)
+    def fromText(cls, s, lazy=False):
+        return cls.from_text(s, lazy=lazy)
 
     def asText(self, includeSecrets=False):
         return self.to_text(with_password=includeSecrets)

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1506,8 +1506,16 @@ class DecodedURL(object):
 
     @property
     def userinfo(self):
-        return u':'.join([_percent_decode(p, raise_subencoding_exc=True)
-                          for p in self._url.userinfo.split(':', 1)])
+        return tuple([_percent_decode(p, raise_subencoding_exc=True)
+                      for p in self._url.userinfo.split(':', 1)])
+
+    @property
+    def user(self):
+        return self.userinfo[0]
+
+    @property
+    def password(self):
+        return self.userinfo[1]
 
     @property
     def fragment(self):
@@ -1545,6 +1553,39 @@ class DecodedURL(object):
                          for (k, v) in self._url.query]
         return [v for (k, v) in decoded_query if name == k]
 
+    def child(self, *segments):
+        if not segments:
+            return self
+        return type(self)(self._url.child(*segments))
+
+    def sibling(self, segment):
+        return type(self)(self._url.sibling(segment))
+
+    def click(self, href=u''):
+        return type(self)(self._url.click(href=href))
+
+    def normalize(self, *a, **kw):
+        return type(self)(self._url.normalize(*a, **kw))
+
+    def to_uri(self, *a, **kw):
+        return self._url.to_uri(*a, **kw)
+
+    def to_iri(self, *a, **kw):
+        return self._url.to_iri(*a, **kw)
+
+    def to_text(self, *a, **kw):
+        return self._url.to_text(*a, **kw)
+
+    def __repr__(self):
+        cn = self.__class__.__name__
+        return '%s(url=%r)' % (cn, self._url)
+
+    def __str__(self):
+        # TODO: the underlying URL's __str__ needs to change to make
+        # this work as the URL
+        return str(self._url)
+
+
 
 """Probably turn the properties into normal attributes now that they
 raise exceptions, or at least cachedproperties.
@@ -1560,8 +1601,6 @@ raise exceptions, or at least cachedproperties.
   * .get()
 * Wrap in encoder
   * replace
-  * child (split and encode?)
-  * sibling
   * add()
   * set()
   * get()
@@ -1570,6 +1609,8 @@ raise exceptions, or at least cachedproperties.
   * __eq__ / __ne__ / __hash__
   * absolute()
 * Return new DecodedURL with new ._url (the other kind of passthrough)
+  * child (split and encode?)
+  * sibling
   * normalize()
   * click()
 * Strict passthrough (doesn't return a DecodedURL)

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1545,10 +1545,10 @@ class DecodedURL(object):
 
     @property
     def query(self):
-        return [tuple(_percent_decode(x, raise_subencoding_exc=True)
-                      if x is not None else None
-                      for x in (k, v))
-                for k, v in self._url.query]
+        return tuple([tuple(_percent_decode(x, raise_subencoding_exc=True)
+                            if x is not None else None
+                            for x in (k, v))
+                      for k, v in self._url.query])
 
     @property
     def fragment(self):
@@ -1566,6 +1566,10 @@ class DecodedURL(object):
     @property
     def password(self):
         return self.userinfo[1]
+
+    @property
+    def uses_netloc(self):
+        return self._url.uses_netloc
 
     def replace(self, scheme=_UNSET, host=_UNSET, path=_UNSET, query=_UNSET,
                 fragment=_UNSET, port=_UNSET, rooted=_UNSET, userinfo=_UNSET,
@@ -1619,6 +1623,23 @@ class DecodedURL(object):
         # TODO: the underlying URL's __str__ needs to change to make
         # this work as the URL
         return str(self._url)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.to_uri() == other.to_uri()
+
+    def __ne__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self.__class__, self.scheme, self.userinfo, self.host,
+                     self.path, self.query, self.fragment, self.port,
+                     self.rooted, self.uses_netloc))
+
+
 
 
 

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1466,6 +1466,29 @@ class DecodedURL(object):
         return cls(_url)
 
     @property
+    def host(self):
+        host = self._url.host
+        try:
+            host_bytes = host.encode("ascii")
+        except UnicodeEncodeError:
+            host_text = host
+        else:
+            try:
+                host_text = host_bytes.decode("idna")
+            except ValueError:
+                # only reached on "narrow" (UCS-2) Python builds <3.4, see #7
+                # NOTE: not going to raise here, because there's no
+                # ambiguity in the IDNA, and the host is still
+                # technically usable
+                host_text = host
+
+        return host_text
+
+    @property
+    def port(self):
+        return self._url.port
+
+    @property
     def path(self):
         return tuple([_percent_decode(p, raise_subencoding_exc=True)
                       for p in self._url.path])
@@ -1545,6 +1568,7 @@ raise exceptions, or at least cachedproperties.
 * Return new DecodedURL with new ._url (the other kind of passthrough)
   * normalize()
   * click()
+* Strict passthrough (doesn't return a DecodedURL)
   * to_uri()
   * to_iri()
 

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1569,9 +1569,11 @@ class DecodedURL(object):
         return type(self)(url=new_url)
 
     def set(self, name, value=None):
-        new_url = self._url.set(_encode_reserved(name), _encode_reserved(value)
-                                if value is not None else value)
-        return type(self)(url=new_url)
+        query = self.query
+        q = [(k, v) for (k, v) in query if k != name]
+        idx = next((i for (i, (k, v)) in enumerate(query) if k == name), -1)
+        q[idx:idx] = [(_encode_reserved(name), _encode_reserved(value))]
+        return self.replace(query=q)
 
     def remove(self, name):
         return self.replace(query=((k, v) for (k, v) in self.query

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -212,7 +212,7 @@ _ROOT_PATHS = frozenset(((), (u'',)))
 
 def _encode_reserved(text, maximal=True):
     """A very comprehensive percent encoding for encoding all
-    delimeters. Used for arguments to DecodedURL, where a % means a
+    delimiters. Used for arguments to DecodedURL, where a % means a
     percent sign, and not the character used by URLs for escaping
     bytes.
     """

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1517,7 +1517,7 @@ class DecodedURL(object):
     handled automatically.
 
     Where applicable, a UTF-8 encoding is presumed. Be advised that
-    some interactions, can raise :exc:`UnicodeEncodeErrors` and
+    some interactions can raise :exc:`UnicodeEncodeErrors` and
     :exc:`UnicodeDecodeErrors`, just like when working with
     bytestrings. Examples of such interactions include handling query
     strings encoding binary data, and paths containing segments with

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1561,11 +1561,21 @@ class DecodedURL(object):
 
     def get(self, name):
         # TODO: another reason to do this in the __init__
-        decoded_query = [(_percent_decode(k, raise_subencoding_exc=True),
-                          _percent_decode(v, raise_subencoding_exc=True)
-                          if v is not None else v)
-                         for (k, v) in self._url.query]
-        return [v for (k, v) in decoded_query if name == k]
+        return [v for (k, v) in self.query if name == k]
+
+    def add(self, name, value=None):
+        new_url = self._url.add(_encode_reserved(name), _encode_reserved(value)
+                                if value is not None else value)
+        return type(self)(url=new_url)
+
+    def set(self, name, value=None):
+        new_url = self._url.set(_encode_reserved(name), _encode_reserved(value)
+                                if value is not None else value)
+        return type(self)(url=new_url)
+
+    def remove(self, name):
+        return self.replace(query=((k, v) for (k, v) in self.query
+                                   if k != name))
 
     def child(self, *segments):
         if not segments:

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1520,35 +1520,59 @@ class DecodedURL(object):
 
     @classmethod
     def from_text(cls, text, lazy=False):
+        """\
+        Make a DecodedURL instance from any text string containing a URL.
+
+        Args:
+          text (unicode): Text containing the URL
+          lazy (bool): Whether to pre-decode all parts of the URL to
+              check for validity. Defaults to True.
+        """
         _url = URL.from_text(text)
         return cls(_url, lazy=lazy)
 
     @property
     def encoded_url(self):
+        """Access the underlying :class:`URL` object, which has any special
+        characters encoded.
+        """
         return self._url
 
     def to_text(self, *a, **kw):
+        "Passthrough to :meth:`~hyperlink.URL.to_text()`"
         return self._url.to_text(*a, **kw)
 
     def to_uri(self, *a, **kw):
+        "Passthrough to :meth:`~hyperlink.URL.to_uri()`"
         return self._url.to_uri(*a, **kw)
 
     def to_iri(self, *a, **kw):
+        "Passthrough to :meth:`~hyperlink.URL.to_iri()`"
         return self._url.to_iri(*a, **kw)
 
     def click(self, href=u''):
+        "Return a new DecodedURL wrapping the result of :meth:`~hyperlink.URL.click()`"
         return type(self)(self._url.click(href=href))
 
     def sibling(self, segment):
+        """Automatically encode any reserved characters in *segment* and
+        return a new DecodedURL wrapping the result of
+        :meth:`~hyperlink.URL.sibling()`
+        """
         return type(self)(self._url.sibling(_encode_reserved(segment)))
 
     def child(self, *segments):
+        """Automatically encode any reserved characters in *segments* and
+        return a new DecodedURL wrapping the result of
+        :meth:`~hyperlink.URL.child()`.
+        """
         if not segments:
             return self
         new_segs = [_encode_reserved(s) for s in segments]
         return type(self)(self._url.child(*new_segs))
 
     def normalize(self, *a, **kw):
+        "Return a new DecodedURL wrapping the result of :meth:`~hyperlink.URL.normalize()`"
         return type(self)(self._url.normalize(*a, **kw))
 
     @property
@@ -1629,7 +1653,7 @@ class DecodedURL(object):
     def replace(self, scheme=_UNSET, host=_UNSET, path=_UNSET, query=_UNSET,
                 fragment=_UNSET, port=_UNSET, rooted=_UNSET, userinfo=_UNSET,
                 uses_netloc=_UNSET):
-        """While the signature is the same, this replace differs a little from
+        """While the signature is the same, this `replace()` differs a little from
         URL.replace. For instance, it accepts userinfo as a tuple, not
         as a string. As with the rest of the methods on DecodedURL, if
         you pass a reserved character, it will be automatically
@@ -1659,12 +1683,15 @@ class DecodedURL(object):
         return type(self)(url=new_url)
 
     def get(self, name):
+        "Get the value of all query parameters whose name matches *name*"
         return [v for (k, v) in self.query if name == k]
 
     def add(self, name, value=None):
+        "Return a new DecodedURL with the query parameter *name* and *value* added."
         return self.replace(query=self.query + ((name, value),))
 
     def set(self, name, value=None):
+        "Return a new DecodedURL with query parameter *name* set to *value*"
         query = self.query
         q = [(k, v) for (k, v) in query if k != name]
         idx = next((i for (i, (k, v)) in enumerate(query) if k == name), -1)
@@ -1672,6 +1699,7 @@ class DecodedURL(object):
         return self.replace(query=q)
 
     def remove(self, name):
+        "Return a new DecodedURL with query parameter *name* removed."
         return self.replace(query=((k, v) for (k, v) in self.query
                                    if k != name))
 

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1466,6 +1466,10 @@ class DecodedURL(object):
         return cls(_url)
 
     @property
+    def scheme(self):
+        return self._url.scheme
+
+    @property
     def host(self):
         host = self._url.host
         try:

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1644,6 +1644,27 @@ class DecodedURL(object):
                      self.path, self.query, self.fragment, self.port,
                      self.rooted, self.uses_netloc))
 
+    # # Begin Twisted Compat Code
+    asURI = to_uri
+    asIRI = to_iri
+
+    @classmethod
+    def fromText(cls, s):
+        return cls.from_text(s)
+
+    def asText(self, includeSecrets=False):
+        return self.to_text(with_password=includeSecrets)
+
+    def __dir__(self):
+        try:
+            ret = object.__dir__(self)
+        except AttributeError:
+            # object.__dir__ == AttributeError  # pdw for py2
+            ret = dir(self.__class__) + list(self.__dict__.keys())
+        ret = sorted(set(ret) - set(['fromText', 'asURI', 'asIRI', 'asText']))
+        return ret
+
+    # # End Twisted Compat Code
 
 
 

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1479,6 +1479,34 @@ class DecodedURL(object):
         _url = URL.from_text(text)
         return cls(_url)
 
+    def to_text(self, *a, **kw):
+        return self._url.to_text(*a, **kw)
+
+    def to_uri(self, *a, **kw):
+        return self._url.to_uri(*a, **kw)
+
+    def to_iri(self, *a, **kw):
+        return self._url.to_iri(*a, **kw)
+
+    def click(self, href=u''):
+        return type(self)(self._url.click(href=href))
+
+    def sibling(self, segment):
+        return type(self)(self._url.sibling(_encode_reserved(segment)))
+
+    def child(self, *segments):
+        if not segments:
+            return self
+        new_segs = [_encode_reserved(s) for s in segments]
+        return type(self)(self._url.child(*new_segs))
+
+    def normalize(self, *a, **kw):
+        return type(self)(self._url.normalize(*a, **kw))
+
+    @property
+    def absolute(self):
+        return self._url.absolute
+
     @property
     def scheme(self):
         return self._url.scheme
@@ -1507,6 +1535,10 @@ class DecodedURL(object):
         return self._url.port
 
     @property
+    def rooted(self):
+        return self._url.rooted
+
+    @property
     def path(self):
         return tuple([_percent_decode(p, raise_subencoding_exc=True)
                       for p in self._url.path])
@@ -1517,6 +1549,10 @@ class DecodedURL(object):
                       if x is not None else None
                       for x in (k, v))
                 for k, v in self._url.query]
+
+    @property
+    def fragment(self):
+        return _percent_decode(self._url.fragment, raise_subencoding_exc=True)
 
     @property
     def userinfo(self):
@@ -1530,10 +1566,6 @@ class DecodedURL(object):
     @property
     def password(self):
         return self.userinfo[1]
-
-    @property
-    def fragment(self):
-        return _percent_decode(self._url.fragment, raise_subencoding_exc=True)
 
     def replace(self, scheme=_UNSET, host=_UNSET, path=_UNSET, query=_UNSET,
                 fragment=_UNSET, port=_UNSET, rooted=_UNSET, userinfo=_UNSET,
@@ -1578,30 +1610,6 @@ class DecodedURL(object):
     def remove(self, name):
         return self.replace(query=((k, v) for (k, v) in self.query
                                    if k != name))
-
-    def child(self, *segments):
-        if not segments:
-            return self
-        new_segs = [_encode_reserved(s) for s in segments]
-        return type(self)(self._url.child(*new_segs))
-
-    def sibling(self, segment):
-        return type(self)(self._url.sibling(_encode_reserved(segment)))
-
-    def click(self, href=u''):
-        return type(self)(self._url.click(href=href))
-
-    def normalize(self, *a, **kw):
-        return type(self)(self._url.normalize(*a, **kw))
-
-    def to_uri(self, *a, **kw):
-        return self._url.to_uri(*a, **kw)
-
-    def to_iri(self, *a, **kw):
-        return self._url.to_iri(*a, **kw)
-
-    def to_text(self, *a, **kw):
-        return self._url.to_text(*a, **kw)
 
     def __repr__(self):
         cn = self.__class__.__name__

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1461,17 +1461,26 @@ class DecodedURL(object):
     def path(self):
         return tuple([_percent_decode(p) for p in self._url.path])
 
+    @property
+    def query(self):
+        return [tuple(_percent_decode(x)
+                      if x is not None else None
+                      for x in (k, v))
+                for k, v in self._url.query]
+
     def replace(self, scheme=_UNSET, host=_UNSET, path=_UNSET, query=_UNSET,
                 fragment=_UNSET, port=_UNSET, rooted=_UNSET, userinfo=_UNSET,
                 uses_netloc=_UNSET):
         if path is not _UNSET:
             path = _encode_path_parts(path, maximal=False, joined=False)
         if query is not _UNSET:
-            query = tuple([_encode_query_part(x, maximal=False)
-                           for x in ([k] if v is None else [k, v])
-                           for (k, v) in query])
+            query = [[_encode_query_part(x)
+                      if x is not None else None
+                      for x in (k, v)]
+                     for k, v in iter_pairs(query)]
         if userinfo is not _UNSET:
-            userinfo = _encode_userinfo_part(userinfo, maximal=False)
+            userinfo = u':'.join([_encode_userinfo_part(p) for p in
+                                  self.userinfo.split(':', 1)])
         new_url = self._url.replace(scheme=scheme,
                                     host=host,
                                     path=path,

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -109,3 +109,12 @@ def test_replace_roundtrip():
                          uses_netloc=durl.uses_netloc)
 
     assert durl == durl2
+
+
+def test_twisted_compat():
+    durl = DecodedURL.from_text(TOTAL_URL)
+
+    assert durl == DecodedURL.fromText(TOTAL_URL)
+    assert 'to_text' in dir(durl)
+    assert 'asText' not in dir(durl)
+    assert durl.to_text() == durl.asText()

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -93,3 +93,19 @@ def test_equivalences():
     durl_map[durl2] = durl2
 
     assert len(durl_map) == 1
+
+
+def test_replace_roundtrip():
+    durl = DecodedURL.from_text(TOTAL_URL)
+
+    durl2 = durl.replace(scheme=durl.scheme,
+                         host=durl.host,
+                         path=durl.path,
+                         query=durl.query,
+                         fragment=durl.fragment,
+                         port=durl.port,
+                         rooted=durl.rooted,
+                         userinfo=durl.userinfo,
+                         uses_netloc=durl.uses_netloc)
+
+    assert durl == durl2

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -48,6 +48,22 @@ def test_passthroughs():
 
     assert durl.to_text(with_password=True) == TOTAL_URL
 
+
 def test_repr():
     durl = DecodedURL.from_text(TOTAL_URL)
     assert repr(durl) == 'DecodedURL(url=' + repr(durl._url) + ')'
+
+
+def test_query_manipulation():
+    durl = DecodedURL.from_text(TOTAL_URL)
+
+    assert durl.get('zot') == ['23%']
+    durl = durl.add(' ', 'space')
+    assert durl.get(' ') == ['space']
+    durl = durl.set(' ', 'spa%ed')
+    assert durl.get(' ') == ['spa%ed']
+
+    durl = DecodedURL(url=durl.to_uri())
+    assert durl.get(' ') == ['spa%ed']
+    durl = durl.remove(' ')
+    assert durl.get(' ') == []

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -75,3 +75,21 @@ def test_query_manipulation():
     assert durl.get('arg') == ['b', 'c']
 
     assert durl.set('arg', 'd').get('arg') == ['d']
+
+
+def test_equivalences():
+    durl = DecodedURL.from_text(TOTAL_URL)
+    durl2 = DecodedURL.from_text(TOTAL_URL)
+    burl = DecodedURL.from_text(BASIC_URL)
+
+    assert durl == durl
+    assert durl == durl2
+    assert durl != burl
+    assert durl != None
+    assert durl != durl._url
+
+    durl_map = {}
+    durl_map[durl] = durl
+    durl_map[durl2] = durl2
+
+    assert len(durl_map) == 1

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from hyperlink import DecodedURL
+
+BASIC_URL = "http://www.foo.com:8080/a/nice%20nice/path/?zot=23%25&zut#frég"
+
+
+def test_durl_basic():
+    durl = DecodedURL.from_text(BASIC_URL)
+
+    assert durl.path == ('a', 'nice nice', 'path', '')
+    assert durl.fragment == 'frég'
+    assert durl.get('zot') == ['23%']

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -26,7 +26,6 @@ def test_durl_basic():
     assert durl.get('zot') == ['23%']
 
     assert durl.user == 'user'
-    assert durl.password == '\0\0\0\0'
     assert durl.userinfo == ('user', '\0\0\0\0')
 
 
@@ -37,6 +36,8 @@ def test_passthroughs():
     durl = DecodedURL.from_text(TOTAL_URL)
     assert durl.sibling('te%t').path[-1] == 'te%t'
     assert durl.child('../test2%').path[-1] == '../test2%'
+    assert durl.child() == durl
+    assert durl.child() is durl
     assert durl.click('/').path[-1] == ''
     assert durl.user == 'user'
 
@@ -50,6 +51,11 @@ def test_passthroughs():
 
     assert durl.absolute
     assert durl.rooted
+
+    assert durl == durl.encoded_url.get_decoded_url()
+
+    durl2 = DecodedURL.from_text(TOTAL_URL, lazy=True)
+    assert durl2 == durl2.encoded_url.get_decoded_url(lazy=True)
 
 
 def test_repr():

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -4,12 +4,14 @@ from __future__ import unicode_literals
 
 from hyperlink import DecodedURL
 
-BASIC_URL = "http://www.foo.com:8080/a/nice%20nice/path/?zot=23%25&zut#frég"
+BASIC_URL = "http://xn--bcher-kva.ch:8080/a/nice%20nice/path/?zot=23%25&zut#frég"
 
 
 def test_durl_basic():
     durl = DecodedURL.from_text(BASIC_URL)
 
+    assert durl.host == 'bücher.ch'
+    assert durl.port == 8080
     assert durl.path == ('a', 'nice nice', 'path', '')
     assert durl.fragment == 'frég'
     assert durl.get('zot') == ['23%']

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -2,125 +2,134 @@
 
 from __future__ import unicode_literals
 
-from hyperlink import DecodedURL
+from .. import DecodedURL
+from .common import HyperlinkTestCase
 
 BASIC_URL = 'http://example.com/#'
 TOTAL_URL = "https://%75%73%65%72:%00%00%00%00@xn--bcher-kva.ch:8080/a/nice%20nice/./path/?zot=23%25&zut#frég"
 
 
-def test_durl_basic():
-    bdurl = DecodedURL.from_text(BASIC_URL)
-    assert bdurl.scheme == 'http'
-    assert bdurl.host == 'example.com'
-    assert bdurl.port == 80
-    assert bdurl.path == ('',)
-    assert bdurl.fragment == ''
+class TestURL(HyperlinkTestCase):
 
-    durl = DecodedURL.from_text(TOTAL_URL)
+    def test_durl_basic(self):
+        bdurl = DecodedURL.from_text(BASIC_URL)
+        assert bdurl.scheme == 'http'
+        assert bdurl.host == 'example.com'
+        assert bdurl.port == 80
+        assert bdurl.path == ('',)
+        assert bdurl.fragment == ''
 
-    assert durl.scheme == 'https'
-    assert durl.host == 'bücher.ch'
-    assert durl.port == 8080
-    assert durl.path == ('a', 'nice nice', '.', 'path', '')
-    assert durl.fragment == 'frég'
-    assert durl.get('zot') == ['23%']
+        durl = DecodedURL.from_text(TOTAL_URL)
 
-    assert durl.user == 'user'
-    assert durl.userinfo == ('user', '\0\0\0\0')
+        assert durl.scheme == 'https'
+        assert durl.host == 'bücher.ch'
+        assert durl.port == 8080
+        assert durl.path == ('a', 'nice nice', '.', 'path', '')
+        assert durl.fragment == 'frég'
+        assert durl.get('zot') == ['23%']
 
+        assert durl.user == 'user'
+        assert durl.userinfo == ('user', '\0\0\0\0')
 
-def test_passthroughs():
-    # just basic tests for the methods that more or less pass straight
-    # through to the underlying URL
+    def test_passthroughs(self):
+        # just basic tests for the methods that more or less pass straight
+        # through to the underlying URL
 
-    durl = DecodedURL.from_text(TOTAL_URL)
-    assert durl.sibling('te%t').path[-1] == 'te%t'
-    assert durl.child('../test2%').path[-1] == '../test2%'
-    assert durl.child() == durl
-    assert durl.child() is durl
-    assert durl.click('/').path[-1] == ''
-    assert durl.user == 'user'
+        durl = DecodedURL.from_text(TOTAL_URL)
+        assert durl.sibling('te%t').path[-1] == 'te%t'
+        assert durl.child('../test2%').path[-1] == '../test2%'
+        assert durl.child() == durl
+        assert durl.child() is durl
+        assert durl.click('/').path[-1] == ''
+        assert durl.user == 'user'
 
-    assert '.' in durl.path
-    assert '.' not in durl.normalize().path
+        assert '.' in durl.path
+        assert '.' not in durl.normalize().path
 
-    assert durl.to_uri().fragment == 'fr%C3%A9g'
-    assert ' ' in durl.to_iri().path[1]
+        assert durl.to_uri().fragment == 'fr%C3%A9g'
+        assert ' ' in durl.to_iri().path[1]
 
-    assert durl.to_text(with_password=True) == TOTAL_URL
+        assert durl.to_text(with_password=True) == TOTAL_URL
 
-    assert durl.absolute
-    assert durl.rooted
+        assert durl.absolute
+        assert durl.rooted
 
-    assert durl == durl.encoded_url.get_decoded_url()
+        assert durl == durl.encoded_url.get_decoded_url()
 
-    durl2 = DecodedURL.from_text(TOTAL_URL, lazy=True)
-    assert durl2 == durl2.encoded_url.get_decoded_url(lazy=True)
+        durl2 = DecodedURL.from_text(TOTAL_URL, lazy=True)
+        assert durl2 == durl2.encoded_url.get_decoded_url(lazy=True)
 
+        # TODO change this to the actual value when str() changes get merged
+        assert '%20' in str(DecodedURL.from_text(BASIC_URL).child(' '))
 
-def test_repr():
-    durl = DecodedURL.from_text(TOTAL_URL)
-    assert repr(durl) == 'DecodedURL(url=' + repr(durl._url) + ')'
+        assert not (durl == 1)
+        assert durl != 1
 
+    def test_repr(self):
+        durl = DecodedURL.from_text(TOTAL_URL)
+        assert repr(durl) == 'DecodedURL(url=' + repr(durl._url) + ')'
 
-def test_query_manipulation():
-    durl = DecodedURL.from_text(TOTAL_URL)
+    def test_query_manipulation(self):
+        durl = DecodedURL.from_text(TOTAL_URL)
 
-    assert durl.get('zot') == ['23%']
-    durl = durl.add(' ', 'space')
-    assert durl.get(' ') == ['space']
-    durl = durl.set(' ', 'spa%ed')
-    assert durl.get(' ') == ['spa%ed']
+        assert durl.get('zot') == ['23%']
+        durl = durl.add(' ', 'space')
+        assert durl.get(' ') == ['space']
+        durl = durl.set(' ', 'spa%ed')
+        assert durl.get(' ') == ['spa%ed']
 
-    durl = DecodedURL(url=durl.to_uri())
-    assert durl.get(' ') == ['spa%ed']
-    durl = durl.remove(' ')
-    assert durl.get(' ') == []
+        durl = DecodedURL(url=durl.to_uri())
+        assert durl.get(' ') == ['spa%ed']
+        durl = durl.remove(' ')
+        assert durl.get(' ') == []
 
-    durl = DecodedURL.from_text('/?%61rg=b&arg=c')
-    assert durl.get('arg') == ['b', 'c']
+        durl = DecodedURL.from_text('/?%61rg=b&arg=c')
+        assert durl.get('arg') == ['b', 'c']
 
-    assert durl.set('arg', 'd').get('arg') == ['d']
+        assert durl.set('arg', 'd').get('arg') == ['d']
 
+    def test_equivalences(self):
+        durl = DecodedURL.from_text(TOTAL_URL)
+        durl2 = DecodedURL.from_text(TOTAL_URL)
+        burl = DecodedURL.from_text(BASIC_URL)
 
-def test_equivalences():
-    durl = DecodedURL.from_text(TOTAL_URL)
-    durl2 = DecodedURL.from_text(TOTAL_URL)
-    burl = DecodedURL.from_text(BASIC_URL)
+        assert durl == durl
+        assert durl == durl2
+        assert durl != burl
+        assert durl != None
+        assert durl != durl._url
 
-    assert durl == durl
-    assert durl == durl2
-    assert durl != burl
-    assert durl != None
-    assert durl != durl._url
+        durl_map = {}
+        durl_map[durl] = durl
+        durl_map[durl2] = durl2
 
-    durl_map = {}
-    durl_map[durl] = durl
-    durl_map[durl2] = durl2
+        assert len(durl_map) == 1
 
-    assert len(durl_map) == 1
+    def test_replace_roundtrip(self):
+        durl = DecodedURL.from_text(TOTAL_URL)
 
+        durl2 = durl.replace(scheme=durl.scheme,
+                             host=durl.host,
+                             path=durl.path,
+                             query=durl.query,
+                             fragment=durl.fragment,
+                             port=durl.port,
+                             rooted=durl.rooted,
+                             userinfo=durl.userinfo,
+                             uses_netloc=durl.uses_netloc)
 
-def test_replace_roundtrip():
-    durl = DecodedURL.from_text(TOTAL_URL)
+        assert durl == durl2
 
-    durl2 = durl.replace(scheme=durl.scheme,
-                         host=durl.host,
-                         path=durl.path,
-                         query=durl.query,
-                         fragment=durl.fragment,
-                         port=durl.port,
-                         rooted=durl.rooted,
-                         userinfo=durl.userinfo,
-                         uses_netloc=durl.uses_netloc)
+    def test_replace_userinfo(self):
+        durl = DecodedURL.from_text(TOTAL_URL)
+        with self.assertRaises(ValueError):
+            durl.replace(userinfo=['user', 'pw', 'thiswillcauseafailure'])
+        return
 
-    assert durl == durl2
+    def test_twisted_compat(self):
+        durl = DecodedURL.from_text(TOTAL_URL)
 
-
-def test_twisted_compat():
-    durl = DecodedURL.from_text(TOTAL_URL)
-
-    assert durl == DecodedURL.fromText(TOTAL_URL)
-    assert 'to_text' in dir(durl)
-    assert 'asText' not in dir(durl)
-    assert durl.to_text() == durl.asText()
+        assert durl == DecodedURL.fromText(TOTAL_URL)
+        assert 'to_text' in dir(durl)
+        assert 'asText' not in dir(durl)
+        assert durl.to_text() == durl.asText()

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from .. import DecodedURL
+from .._url import _percent_decode
 from .common import HyperlinkTestCase
 
 BASIC_URL = 'http://example.com/#'
@@ -133,3 +134,6 @@ class TestURL(HyperlinkTestCase):
         assert 'to_text' in dir(durl)
         assert 'asText' not in dir(durl)
         assert durl.to_text() == durl.asText()
+
+    def test_percent_decode_bytes(self):
+        assert _percent_decode('%00', subencoding=False) == b'\0'

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -25,14 +25,18 @@ def test_durl_basic():
     assert durl.fragment == 'frég'
     assert durl.get('zot') == ['23%']
 
+    assert durl.user == 'user'
+    assert durl.password == '\0\0\0\0'
+    assert durl.userinfo == ('user', '\0\0\0\0')
+
 
 def test_passthroughs():
     # just basic tests for the methods that more or less pass straight
     # through to the underlying URL
 
     durl = DecodedURL.from_text(TOTAL_URL)
-    assert durl.sibling('test').path[-1] == 'test'
-    assert durl.child('../test2').path[-1] == '../test2'
+    assert durl.sibling('te%t').path[-1] == 'te%t'
+    assert durl.child('../test2%').path[-1] == '../test2%'
     assert durl.click('/').path[-1] == ''
     assert durl.user == 'user'
 

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -67,3 +67,8 @@ def test_query_manipulation():
     assert durl.get(' ') == ['spa%ed']
     durl = durl.remove(' ')
     assert durl.get(' ') == []
+
+    durl = DecodedURL.from_text('/?%61rg=b&arg=c')
+    assert durl.get('arg') == ['b', 'c']
+
+    assert durl.set('arg', 'd').get('arg') == ['d']

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -48,6 +48,9 @@ def test_passthroughs():
 
     assert durl.to_text(with_password=True) == TOTAL_URL
 
+    assert durl.absolute
+    assert durl.rooted
+
 
 def test_repr():
     durl = DecodedURL.from_text(TOTAL_URL)

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from hyperlink import DecodedURL
 
 BASIC_URL = 'http://example.com/#'
-TOTAL_URL = "https://%75%73%65%72:%00%00%00%00@xn--bcher-kva.ch:8080/a/nice%20nice/path/?zot=23%25&zut#frég"
+TOTAL_URL = "https://%75%73%65%72:%00%00%00%00@xn--bcher-kva.ch:8080/a/nice%20nice/./path/?zot=23%25&zut#frég"
 
 
 def test_durl_basic():
@@ -18,8 +18,32 @@ def test_durl_basic():
 
     durl = DecodedURL.from_text(TOTAL_URL)
 
+    assert durl.scheme == 'https'
     assert durl.host == 'bücher.ch'
     assert durl.port == 8080
-    assert durl.path == ('a', 'nice nice', 'path', '')
+    assert durl.path == ('a', 'nice nice', '.', 'path', '')
     assert durl.fragment == 'frég'
     assert durl.get('zot') == ['23%']
+
+
+def test_passthroughs():
+    # just basic tests for the methods that more or less pass straight
+    # through to the underlying URL
+
+    durl = DecodedURL.from_text(TOTAL_URL)
+    assert durl.sibling('test').path[-1] == 'test'
+    assert durl.child('../test2').path[-1] == '../test2'
+    assert durl.click('/').path[-1] == ''
+    assert durl.user == 'user'
+
+    assert '.' in durl.path
+    assert '.' not in durl.normalize().path
+
+    assert durl.to_uri().fragment == 'fr%C3%A9g'
+    assert ' ' in durl.to_iri().path[1]
+
+    assert durl.to_text(with_password=True) == TOTAL_URL
+
+def test_repr():
+    durl = DecodedURL.from_text(TOTAL_URL)
+    assert repr(durl) == 'DecodedURL(url=' + repr(durl._url) + ')'

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -60,8 +60,7 @@ class TestURL(HyperlinkTestCase):
         durl2 = DecodedURL.from_text(TOTAL_URL, lazy=True)
         assert durl2 == durl2.encoded_url.get_decoded_url(lazy=True)
 
-        # TODO change this to the actual value when str() changes get merged
-        assert '%20' in str(DecodedURL.from_text(BASIC_URL).child(' '))
+        assert str(DecodedURL.from_text(BASIC_URL).child(' ')) == 'http://example.com/%20'
 
         assert not (durl == 1)
         assert durl != 1
@@ -89,10 +88,11 @@ class TestURL(HyperlinkTestCase):
 
         assert durl.set('arg', 'd').get('arg') == ['d']
 
-    def test_equivalences(self):
+    def test_equality_and_hashability(self):
         durl = DecodedURL.from_text(TOTAL_URL)
         durl2 = DecodedURL.from_text(TOTAL_URL)
         burl = DecodedURL.from_text(BASIC_URL)
+        durl_uri = durl.to_uri()
 
         assert durl == durl
         assert durl == durl2
@@ -105,6 +105,14 @@ class TestURL(HyperlinkTestCase):
         durl_map[durl2] = durl2
 
         assert len(durl_map) == 1
+
+        durl_map[burl] = burl
+
+        assert len(durl_map) == 2
+
+        durl_map[durl_uri] = durl_uri
+
+        assert len(durl_map) == 3
 
     def test_replace_roundtrip(self):
         durl = DecodedURL.from_text(TOTAL_URL)

--- a/hyperlink/test/test_decoded_url.py
+++ b/hyperlink/test/test_decoded_url.py
@@ -4,11 +4,19 @@ from __future__ import unicode_literals
 
 from hyperlink import DecodedURL
 
-BASIC_URL = "http://xn--bcher-kva.ch:8080/a/nice%20nice/path/?zot=23%25&zut#frég"
+BASIC_URL = 'http://example.com/#'
+TOTAL_URL = "https://%75%73%65%72:%00%00%00%00@xn--bcher-kva.ch:8080/a/nice%20nice/path/?zot=23%25&zut#frég"
 
 
 def test_durl_basic():
-    durl = DecodedURL.from_text(BASIC_URL)
+    bdurl = DecodedURL.from_text(BASIC_URL)
+    assert bdurl.scheme == 'http'
+    assert bdurl.host == 'example.com'
+    assert bdurl.port == 80
+    assert bdurl.path == ('',)
+    assert bdurl.fragment == ''
+
+    durl = DecodedURL.from_text(TOTAL_URL)
 
     assert durl.host == 'bücher.ch'
     assert durl.port == 8080

--- a/hyperlink/test/test_parse.py
+++ b/hyperlink/test/test_parse.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from hyperlink import parse, EncodedURL, DecodedURL
+
+BASIC_URL = 'http://example.com/#'
+TOTAL_URL = "https://%75%73%65%72:%00%00%00%00@xn--bcher-kva.ch:8080/a/nice%20nice/./path/?zot=23%25&zut#frég"
+UNDECODABLE_FRAG_URL = TOTAL_URL + '%C3'
+
+def test_parse():
+    purl = parse(TOTAL_URL)
+    assert isinstance(purl, DecodedURL)
+    assert purl.user == 'user'
+    assert purl.get('zot') == ['23%']
+    assert purl.fragment == 'frég'
+
+    purl2 = parse(TOTAL_URL, decoded=False)
+    assert isinstance(purl2, EncodedURL)
+    assert purl2.get('zot') == ['23%25']
+
+    try:
+        purl3 = parse(UNDECODABLE_FRAG_URL)
+    except UnicodeDecodeError:
+        pass
+    else:
+        assert False, 'expected UnicodeDecodeError due to parse(lazy=False) by default'
+
+    try:
+        purl3 = parse(UNDECODABLE_FRAG_URL, lazy=True)
+    except UnicodeDecodeError:
+        assert False, 'expected UnicodeDecodeError due to parse(lazy=True)'
+
+    try:
+        purl3.fragment
+    except UnicodeDecodeError:
+        pass
+    else:
+        assert False, 'expected UnicodeDecodeError due to undecodable fragment'

--- a/hyperlink/test/test_parse.py
+++ b/hyperlink/test/test_parse.py
@@ -8,6 +8,8 @@ from hyperlink import parse, EncodedURL, DecodedURL
 BASIC_URL = 'http://example.com/#'
 TOTAL_URL = "https://%75%73%65%72:%00%00%00%00@xn--bcher-kva.ch:8080/a/nice%20nice/./path/?zot=23%25&zut#frég"
 UNDECODABLE_FRAG_URL = TOTAL_URL + '%C3'
+# the %C3 above percent-decodes to an unpaired \xc3 byte which makes this
+# invalid utf8
 
 
 class TestURL(HyperlinkTestCase):

--- a/hyperlink/test/test_parse.py
+++ b/hyperlink/test/test_parse.py
@@ -2,38 +2,32 @@
 
 from __future__ import unicode_literals
 
+from .common import HyperlinkTestCase
 from hyperlink import parse, EncodedURL, DecodedURL
 
 BASIC_URL = 'http://example.com/#'
 TOTAL_URL = "https://%75%73%65%72:%00%00%00%00@xn--bcher-kva.ch:8080/a/nice%20nice/./path/?zot=23%25&zut#frég"
 UNDECODABLE_FRAG_URL = TOTAL_URL + '%C3'
 
-def test_parse():
-    purl = parse(TOTAL_URL)
-    assert isinstance(purl, DecodedURL)
-    assert purl.user == 'user'
-    assert purl.get('zot') == ['23%']
-    assert purl.fragment == 'frég'
 
-    purl2 = parse(TOTAL_URL, decoded=False)
-    assert isinstance(purl2, EncodedURL)
-    assert purl2.get('zot') == ['23%25']
+class TestURL(HyperlinkTestCase):
+    def test_parse(self):
+        purl = parse(TOTAL_URL)
+        assert isinstance(purl, DecodedURL)
+        assert purl.user == 'user'
+        assert purl.get('zot') == ['23%']
+        assert purl.fragment == 'frég'
 
-    try:
-        purl3 = parse(UNDECODABLE_FRAG_URL)
-    except UnicodeDecodeError:
-        pass
-    else:
-        assert False, 'expected UnicodeDecodeError due to parse(lazy=False) by default'
+        purl2 = parse(TOTAL_URL, decoded=False)
+        assert isinstance(purl2, EncodedURL)
+        assert purl2.get('zot') == ['23%25']
 
-    try:
+        with self.assertRaises(UnicodeDecodeError):
+            purl3 = parse(UNDECODABLE_FRAG_URL)
+
         purl3 = parse(UNDECODABLE_FRAG_URL, lazy=True)
-    except UnicodeDecodeError:
-        assert False, 'expected UnicodeDecodeError due to parse(lazy=True)'
 
-    try:
-        purl3.fragment
-    except UnicodeDecodeError:
-        pass
-    else:
-        assert False, 'expected UnicodeDecodeError due to undecodable fragment'
+        with self.assertRaises(UnicodeDecodeError):
+            purl3.fragment
+
+        return


### PR DESCRIPTION
This still needs some documentation, but to address #44 and the handful of issues surrounding the central problem, I present `DecodedURL`. It takes care of handling reserved characters so you don't have to. 

From the docstring:

> DecodedURL is a type meant to act as a higher-level interface to the URL. It is the unicode to URL's bytes. DecodedURL has almost exactly the same API as URL, but everything going in and out is in its maximally decoded state. All percent decoding is handled automatically.
> 
> Where applicable, a UTF-8 encoding is presumed. Be advised that some interactions, can raise UnicodeEncodeErrors and UnicodeDecodeErrors, just like when working with bytestrings.
> 
> Examples of such interactions include handling query strings encoding binary data, and paths containing segments with special characters encoded with codecs other than UTF-8. 

It's tested, works, and seems practical, though, so take a look!