### PR TITLE
add and test URL.__str__, which enables URLs to be passed directly to…

### DIFF
--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1343,6 +1343,21 @@ class URL(object):
         """
         return '%s.from_text(%r)' % (self.__class__.__name__, self.to_text())
 
+    def _to_bytes(self):
+        """
+        Allows for direct usage of URL objects with libraries like
+        requests, which automatically stringify URL parameters. See
+        issue #49. Note that some libraries may not handle IRIs well.
+        """
+        return self.to_text().encode('utf8')
+
+    if PY2:
+        __str__ = _to_bytes
+        __unicode__ = to_text
+    else:
+        __bytes__ = _to_bytes
+        __str__ = to_text
+
     # # Begin Twisted Compat Code
     asURI = to_uri
     asIRI = to_iri

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1347,7 +1347,7 @@ class URL(object):
         """
         Allows for direct usage of URL objects with libraries like
         requests, which automatically stringify URL parameters. See
-        issue #49. Note that some libraries may not handle IRIs well.
+        issue #49.
         """
         return self.to_uri().to_text().encode('ascii')
 

--- a/hyperlink/_url.py
+++ b/hyperlink/_url.py
@@ -1349,7 +1349,7 @@ class URL(object):
         requests, which automatically stringify URL parameters. See
         issue #49. Note that some libraries may not handle IRIs well.
         """
-        return self.to_text().encode('utf8')
+        return self.to_uri().to_text().encode('ascii')
 
     if PY2:
         __str__ = _to_bytes

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -1159,7 +1159,7 @@ class TestURL(HyperlinkTestCase):
         text = u'http://example.com/á/y%20a%20y/?b=%25'
         url = URL.from_text(text)
         assert unicode(url) == text
-        assert bytes(url) == text.encode('utf8')
+        assert bytes(url) == b'http://example.com/%C3%A1/y%20a%20y/?b=%25'
 
         if PY2:
             assert isinstance(str(url), bytes)

--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -5,6 +5,7 @@
 
 from __future__ import unicode_literals
 
+import sys
 import socket
 
 from .common import HyperlinkTestCase
@@ -13,6 +14,8 @@ from .. import URL, URLParseError
 from .. import _url
 from .._url import inet_pton, SCHEME_PORT_MAP, parse_host
 
+
+PY2 = (sys.version_info[0] == 2)
 unicode = type(u'')
 
 
@@ -1150,3 +1153,17 @@ class TestURL(HyperlinkTestCase):
 
         # test invalid percent encoding during normalize
         assert URL(path=('', '%te%sts')).normalize().to_text() == '/%te%sts'
+
+    def test_str(self):
+        # see also issue #49
+        text = u'http://example.com/á/y%20a%20y/?b=%25'
+        url = URL.from_text(text)
+        assert unicode(url) == text
+        assert bytes(url) == text.encode('utf8')
+
+        if PY2:
+            assert isinstance(str(url), bytes)
+            assert isinstance(unicode(url), unicode)
+        else:
+            assert isinstance(str(url), unicode)
+            assert isinstance(bytes(url), bytes)


### PR DESCRIPTION
This `URL.__str__()` enables URLs to be passed directly to libaries which stringify (like requests), as brought up by issue #49.

I've opted to keep it simple and have Python 2's `__str__` (Py3's `__bytes__()`) return the UTF-8 encoded version of `URL.to_text()`. This means that when printed on terminals configured to display UTF-8, the user will get a copy-and-pastable URL.

I also considered making `__str__` return the ASCII-encoded `URL.to_url().to_text()`, but this would have the property of obscuring special characters and possibly falsely-equating URIs and IRIs, contrary to hyperlink's longstanding design.