### PR TITLE
Switch to using idna package

### DIFF
--- a/hyperlink/test/test_url.py
+++ b/hyperlink/test/test_url.py
@@ -1167,3 +1167,17 @@ class TestURL(HyperlinkTestCase):
         else:
             assert isinstance(str(url), unicode)
             assert isinstance(bytes(url), bytes)
+
+    def test_idna_corners(self):
+        text = u'http://abé.com/'
+        url = URL.from_text(text)
+        assert url.to_iri().host == u'abé.com'
+        assert url.to_uri().host == u'xn--ab-cja.com'
+
+        url = URL.from_text("http://ドメイン.テスト.co.jp#test")
+        assert url.to_iri().host == u'ドメイン.テスト.co.jp'
+        assert url.to_uri().host == u'xn--eckwd4c7c.xn--zckzah.co.jp'
+
+        assert url.to_uri().get_decoded_url().host == u'ドメイン.テスト.co.jp'
+
+        assert URL.from_text('http://Example.com').to_uri().get_decoded_url().host == 'example.com'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
+coverage==4.4.1
+idna==2.5
 pytest==2.9.2
 pytest-cov==2.3.0
 tox==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 
 __author__ = 'Mahmoud Hashemi and Glyph Lefkowitz'
-__version__ = '17.3.2dev'
+__version__ = '18.0.0dev'
 __contact__ = 'mahmoud@hatnote.com'
 __url__ = 'https://github.com/python-hyper/hyperlink'
 __license__ = 'MIT'
@@ -19,7 +19,7 @@ __license__ = 'MIT'
 
 setup(name='hyperlink',
       version=__version__,
-      description="A featureful, correct URL for Python.",
+      description="A featureful, immutable, and correct URL for Python.",
       long_description=__doc__,
       author=__author__,
       author_email=__contact__,
@@ -29,7 +29,7 @@ setup(name='hyperlink',
       zip_safe=False,
       license=__license__,
       platforms='any',
-      install_requires=['idna>=2.5,<2.7'],
+      install_requires=['idna>=2.5'],
       classifiers=[
           'Topic :: Utilities',
           'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(name='hyperlink',
       zip_safe=False,
       license=__license__,
       platforms='any',
+      install_requires=['idna>=2.5,<2.7'],
       classifiers=[
           'Topic :: Utilities',
           'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py26,py27,py34,py35,py36,pypy,coverage-report,packaging
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt
-commands = coverage run --parallel --rcfile {toxinidir}/.tox-coveragerc -m pytest --doctest-modules {envsitepackagesdir}/hyperlink {posargs}
+commands = coverage run --parallel --omit 'flycheck__*' --rcfile {toxinidir}/.tox-coveragerc -m pytest --doctest-modules {envsitepackagesdir}/hyperlink {posargs}
 
 # Uses default basepython otherwise reporting doesn't work on Travis where
 # Python 3.6 is only available in 3.6 jobs.


### PR DESCRIPTION
As discussed in issue #19, Python's builtin idna support is outdated and broken. Thankfully the [idna](https://github.com/kjd/idna/) package exists. This PR switches to using that, instead of Python's builtin idna codec.