### PR TITLE
Make first examples work

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Then, hyperlink away!
 ```python
 from hyperlink import URL
 
-url = URL.from_text(u'http://github.com/mahmoud/hyperlink?utm_source=README')
+url = URL.from_text('http://github.com/python-hyper/hyperlink?utm_source=README')
 utm_source = url.get(u'utm_source')
-better_url = url.replace(scheme=u'https')
-user_url = better_url.click(u'..')
+better_url = url.replace(scheme='https', port=443)
+org_url = better_url.click('.')
 ```
 
 See the full API docs on [Read the Docs][docs].

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Then, hyperlink away!
 ```python
 from hyperlink import URL
 
-url = URL.from_text('http://github.com/python-hyper/hyperlink?utm_source=README')
+url = URL.from_text(u'http://github.com/python-hyper/hyperlink?utm_source=README')
 utm_source = url.get(u'utm_source')
-better_url = url.replace(scheme='https', port=443)
-org_url = better_url.click('.')
+better_url = url.replace(scheme=u'https', port=443)
+org_url = better_url.click(u'.')
 ```
 
 See the full API docs on [Read the Docs][docs].

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,15 +39,15 @@ Then, URLs are just an import away::
 
   from hyperlink import URL
 
-  url = URL.from_text('http://github.com/python-hyper/hyperlink?utm_souce=readthedocs')
+  url = URL.from_text(u'http://github.com/python-hyper/hyperlink?utm_source=readthedocs')
 
-  better_url = url.replace(scheme='https', port=443)
-  org_url = better_url.click('.')
+  better_url = url.replace(scheme=u'https', port=443)
+  org_url = better_url.click(u'.')
 
   print(org_url.to_text())
   # prints: https://github.com/python-hyper/
 
-  print(better_url.get('utm_source'))
+  print(better_url.get(u'utm_source'))
   # prints: readthedocs
 
 See :ref:`the API docs <hyperlink_api>` for more usage examples.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,13 +41,13 @@ Then, URLs are just an import away::
 
   url = URL.from_text('http://github.com/python-hyper/hyperlink?utm_souce=readthedocs')
 
-  better_url = url.replace(scheme='https')
-  user_url = better_url.click('..')
+  better_url = url.replace(scheme='https', port=443)
+  org_url = better_url.click('.')
 
-  print(user_url.to_text())
-  # prints: https://github.com/mahmoud
+  print(str(org_url))
+  # prints: https://github.com/python-hyper/
 
-  print(user_url.get('utm_source'))
+  print(better_url.get('utm_source'))
   # prints: readthedocs
 
 See :ref:`the API docs <hyperlink_api>` for more usage examples.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Then, URLs are just an import away::
   better_url = url.replace(scheme='https', port=443)
   org_url = better_url.click('.')
 
-  print(str(org_url))
+  print(org_url.to_text())
   # prints: https://github.com/python-hyper/
 
   print(better_url.get('utm_source'))


### PR DESCRIPTION
The examples were broken in several ways, probably due to changes in the library since they were first written:

* Replacing `scheme` from 'http' to 'https' seems to also require replacing `port` to match, otherwise it is maintained as port 80
* The `click` function on the github URL (without a trailing slash) takes one to `github.com/` rather than the org URL
* The URL referred to has moved, since the project was moved from `github.com/mahmoud` to `github.com/python-hyper` :)
* I also thought `str()` is more natural than `to_text()`