### PR TITLE
Add PyPI license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(name='hyperlink',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: Implementation :: PyPy', ]
+          'Programming Language :: Python :: Implementation :: PyPy',
+          'License :: OSI Approved :: MIT License', ]
       )
 
 """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 are you've used several just to read this text.
 
 Hyperlink is a featureful, pure-Python implementation of the URL, with
-an emphasis on correctness. BSD licensed.
+an emphasis on correctness. MIT licensed.
 
 See the docs at http://hyperlink.readthedocs.io.
 """


### PR DESCRIPTION
This makes it easier to introspect licenses for installed packages (e.g. with [pip-licenses](https://pypi.org/project/pip-licenses/))