### PR TITLE
Write compiled files into {envtmpdir}/pycache

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,8 @@ passenv =
 setenv =
     PY_MODULE=hyperlink
 
+    test: PYTHONPYCACHEPREFIX={envtmpdir}/pycache
+
     test: COVERAGE_FILE={toxworkdir}/coverage.{envname}
     {coverage_report,codecov}: COVERAGE_FILE={toxworkdir}/coverage
     codecov: COVERAGE_XML={envlogdir}/coverage_report.xml


### PR DESCRIPTION
Keep fewer build artifacts outside of `.tox/`