### PR TITLE
Fix Travis CI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 cache: pip
 
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
-cache:
-directories:
-- $HOME/.cache/pip
+cache: pip
 
 language: python
 


### PR DESCRIPTION
There's currently no caching on the CI:

![image](https://user-images.githubusercontent.com/1324225/71560481-1af39c80-2a73-11ea-9ab6-6412689c084a.png)

* https://travis-ci.org/python-hyper/hyperlink/jobs/622856289#L173

It's due to missing indentation in the config:

```yaml
cache:
directories:
- $HOME/.cache/pip
```

To fix it, indent:

```yaml
cache:
  directories:
    - $HOME/.cache/pip
```

Or, as only pip is being cached, there's a shortcut:

```yaml
cache: pip
```

* https://docs.travis-ci.com/user/caching/#pip-cache

Fixed cache:

![image](https://user-images.githubusercontent.com/1324225/71560473-06af9f80-2a73-11ea-8493-e22b2093d6b0.png)


https://travis-ci.org/hugovk/hyperlink/jobs/630664500#L177

---

Also, `sudo` is no longer needed: 	

* https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
