### PR TITLE
Adding parse and DecodedURL docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,11 +5,43 @@ Hyperlink API
 
 .. automodule:: hyperlink._url
 
+.. contents::
+   :local:
+
 Creation
 --------
 
-Before you can work with URLs, you must create URLs. There are two
-ways to create URLs, from parts and from text.
+Before you can work with URLs, you must create URLs.
+
+Parsing Text
+^^^^^^^^^^^^
+
+If you already have a textual URL, the easiest way to get URL objects
+is with the :func:`parse()` function:
+
+.. autofunction:: hyperlink.parse
+
+By default, :func:`~hyperlink.parse()` returns an instance of
+:class:`DecodedURL`, a URL type that handles all encoding for you, by
+wrapping the lower-level :class:`URL`.
+
+DecodedURL
+^^^^^^^^^^
+
+.. autoclass:: hyperlink.DecodedURL
+.. automethod:: hyperlink.DecodedURL.from_text
+
+The Encoded URL
+^^^^^^^^^^^^^^^
+
+The lower-level :class:`URL` looks very similar to the
+:class:`DecodedURL`, but does not handle all encoding cases for
+you. Use with caution.
+
+.. note::
+
+   :class:`URL` is also available as an alias,
+   ``hyperlink.EncodedURL`` for more explicit usage.
 
 .. autoclass:: hyperlink.URL
 .. automethod:: hyperlink.URL.from_text

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,9 +39,9 @@ library. The easiest way to install is with pip::
 
 Then, URLs are just an import away::
 
-  from hyperlink import URL
+  import hyperlink
 
-  url = URL.from_text(u'http://github.com/python-hyper/hyperlink?utm_source=readthedocs')
+  url = hyperlink.parse(u'http://github.com/python-hyper/hyperlink?utm_source=readthedocs')
 
   better_url = url.replace(scheme=u'https', port=443)
   org_url = better_url.click(u'.')
@@ -49,7 +49,7 @@ Then, URLs are just an import away::
   print(org_url.to_text())
   # prints: https://github.com/python-hyper/
 
-  print(better_url.get(u'utm_source'))
+  print(better_url.get(u'utm_source')[0])
   # prints: readthedocs
 
 See :ref:`the API docs <hyperlink_api>` for more usage examples.


### PR DESCRIPTION
#125 correctly points out, `hyperlink.parse()` and `hyperlink.DecodedURL()` aren't documented, so I put together something quick. 

I think we maybe talked about having URL _become_ DecodedURL at some point, but I'm not sure it's worth waiting for that. 

I think this PR basically brings the docs in line with recommended practices for using hyperlink.

Questions reviewers in the comments.