### PR TITLE
Clean up the Tox config a bit more

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,12 +17,6 @@ basepython = python3.8
 deps =
     idna==2.9
 
-    test: typing==3.7.4.1
-    test: {[testenv:coverage_report]deps}
-    test-{py26,py27,py34}: pytest==4.6.9
-    test-{py35,py36,py37,py38}: pytest==5.2.4
-    test: pytest-cov==2.8.1
-
 setenv =
     PY_MODULE=hyperlink
 
@@ -50,15 +44,27 @@ basepython =
     pypy2: pypy
     pypy3: pypy3
 
-deps = {[default]deps}
+deps =
+    {[default]deps}
+
+    # In Python 2, we need to pull in typing
+    {py26,py27}: typing==3.7.4.1
+
+    # For pytest
+    {py26,py27,py34}: pytest==4.6.9
+    {py35,py36,py37,py38}: pytest==5.2.4
+
+    # For code coverage
+    {[testenv:coverage_report]deps}
+    pytest-cov==2.8.1
 
 setenv =
     {[default]setenv}
 
-    test: COVERAGE_FILE={toxworkdir}/coverage.{envname}
+    COVERAGE_FILE={toxworkdir}/coverage.{envname}
 
 commands =
-    test: pytest --cov={env:PY_MODULE} --cov-report=term-missing:skip-covered --doctest-modules {posargs:src/{env:PY_MODULE}}
+    pytest --cov={env:PY_MODULE} --cov-report=term-missing:skip-covered --doctest-modules {posargs:src/{env:PY_MODULE}}
 
 
 ##


### PR DESCRIPTION
- Move some settings from `[default]` to `[testenv]`, since they are only used there.
- There is no need to prefix testing config with `test:` any more, since `[testenv]` only runs tests.
- Add comments, because yay comments.