### PR TITLE
Install IDNA tables file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     url=__url__,
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    package_data=dict(hyperlink=["py.typed"]),
+    package_data=dict(hyperlink=["py.typed", "idna-tables-properties.csv.gz"]),
     zip_safe=False,
     license=__license__,
     platforms="any",


### PR DESCRIPTION
Install the IDNA tables file.

On trying to switch Klein to [use the Hypothesis strategies now provided by Hyperlink](https://github.com/twisted/klein/pull/393), I got [build failures](https://travis-ci.org/github/twisted/klein/jobs/722089054#L575) due to the file being missing.

I though that `tox -e packaging` would notice this was missing, but it doesn't catch it.
