### PR TITLE
Cap coverage version for requires.io

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -247,7 +247,8 @@ basepython = {[default]basepython}
 skip_install = True
 
 deps =
-    coverage==4.5.4  # rq.filter: <5  # coverage 5.0 drops Python 3.4 support
+    # coverage 5.0 drops Python 3.4 support
+    coverage==4.5.4  # rq.filter: <5
 
 setenv =
     {[default]setenv}


### PR DESCRIPTION
Try moving extra comment out of `rq.filter` line to make `requires.io` happy