### PR TITLE
Reformat a few files with Black

### DIFF
--- a/src/hyperlink/hypothesis.py
+++ b/src/hyperlink/hypothesis.py
@@ -78,7 +78,8 @@ else:
             )
             with open_gzip(dataFileName) as dataFile:
                 reader = csv_reader(
-                    (line.decode("utf-8") for line in dataFile), delimiter=",",
+                    (line.decode("utf-8") for line in dataFile),
+                    delimiter=",",
                 )
                 next(reader)  # Skip header row
                 for row in reader:

--- a/src/hyperlink/test/common.py
+++ b/src/hyperlink/test/common.py
@@ -16,26 +16,26 @@ class HyperlinkTestCase(TestCase):
     ):
         # type: (...) -> Any
         """Fail unless an exception of class expected_exception is raised
-           by callableObj when invoked with arguments args and keyword
-           arguments kwargs. If a different type of exception is
-           raised, it will not be caught, and the test case will be
-           deemed to have suffered an error, exactly as for an
-           unexpected exception.
+        by callableObj when invoked with arguments args and keyword
+        arguments kwargs. If a different type of exception is
+        raised, it will not be caught, and the test case will be
+        deemed to have suffered an error, exactly as for an
+        unexpected exception.
 
-           If called with callableObj omitted or None, will return a
-           context object used like this::
+        If called with callableObj omitted or None, will return a
+        context object used like this::
 
-                with self.assertRaises(SomeException):
-                    do_something()
+             with self.assertRaises(SomeException):
+                 do_something()
 
-           The context manager keeps a reference to the exception as
-           the 'exception' attribute. This allows you to inspect the
-           exception after the assertion::
+        The context manager keeps a reference to the exception as
+        the 'exception' attribute. This allows you to inspect the
+        exception after the assertion::
 
-               with self.assertRaises(SomeException) as cm:
-                   do_something()
-               the_exception = cm.exception
-               self.assertEqual(the_exception.error_code, 3)
+            with self.assertRaises(SomeException) as cm:
+                do_something()
+            the_exception = cm.exception
+            self.assertEqual(the_exception.error_code, 3)
         """
         context = _AssertRaisesContext(expected_exception, self)
         if callableObj is None:

--- a/src/hyperlink/test/test_common.py
+++ b/src/hyperlink/test/test_common.py
@@ -7,15 +7,11 @@ from .common import HyperlinkTestCase
 
 
 class _ExpectedException(Exception):
-    """An exception used to test HyperlinkTestCase.assertRaises.
-
-    """
+    """An exception used to test HyperlinkTestCase.assertRaises."""
 
 
 class _UnexpectedException(Exception):
-    """An exception used to test HyperlinkTestCase.assertRaises.
-
-    """
+    """An exception used to test HyperlinkTestCase.assertRaises."""
 
 
 class TestHyperlink(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -126,8 +126,7 @@ deps =
     pep8-naming==0.11.1
     pycodestyle==2.6.0
     pydocstyle==5.1.1
-    # pin pyflakes pending a release with https://github.com/PyCQA/pyflakes/pull/455
-    git+git://github.com/PyCQA/pyflakes@ffe9386#egg=pyflakes
+    pyflakes==2.2.0
 
 commands =
     flake8 {posargs:setup.py src/{env:PY_MODULE}}


### PR DESCRIPTION
Fix this failure on master:

```
black run-test: commands[0] | black --check setup.py src
would reformat /home/twm/dev/hyperlink/src/hyperlink/test/common.py
would reformat /home/twm/dev/hyperlink/src/hyperlink/test/test_common.py
would reformat /home/twm/dev/hyperlink/src/hyperlink/hypothesis.py
Oh no! 💥 💔 💥
3 files would be reformatted, 11 files would be left unchanged.
ERROR: InvocationError for command /home/twm/dev/hyperlink/.tox/black/bin/black --check setup.py src (exited with code 1)
```