### PR TITLE
GitHub Actions CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -208,7 +208,7 @@ jobs:
           else  # CPython
               py_test="py${py/./}";  # Add "py" prefix, remove "."
           fi;
-          env_test="test-${py_test},codecov";
+          env_test="test-${py_test}";
           echo "Test environment: ${env_test}";
           ln -s ".tox/${env_test}" testenv;  # Fixed location for upload step below
           tox -e "${env_test}";

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,240 @@
+# Docs:
+# https://help.github.com/en/actions/automating-your-workflow-with-github-actions
+
+
+
+name: CI/CD
+
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+
+jobs:
+
+  info:
+
+    name: Workflow information
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+
+    steps:
+
+      - name: Print GitHub Context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "${GITHUB_CONTEXT}";
+
+      - name: Print Job Context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "${JOB_CONTEXT}";
+
+      - name: Print Steps Context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "${STEPS_CONTEXT}";
+
+      - name: Print Runner Context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "${RUNNER_CONTEXT}";
+
+      - name: Print Strategy Context
+        env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        run: echo "${STRATEGY_CONTEXT}";
+
+      - name: Print Matrix Context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "${MATRIX_CONTEXT}";
+
+
+  flake8:
+
+    name: Flake8 (linter)
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.9"
+
+      - name: Install Tox
+        run: pip install tox;
+
+      - name: Run Flake8
+        run: tox -e flake8;
+
+
+  black:
+
+    name: Black (linter)
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.9"
+
+      - name: Install Tox
+        run: pip install tox;
+
+      - name: Run Black
+        run: tox -e black;
+
+
+  mypy:
+    name: Mypy (static type checker)
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.9"
+
+      - name: Install Tox
+        run: pip install tox;
+
+      - name: Run Mypy
+        run: tox -e mypy;
+
+
+  docs:
+
+    name: Build documentation
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.9"
+
+      - name: Install Tox
+        run: pip install tox;
+
+      - name: Build documentation
+        run: tox -e docs;
+
+
+  packaging:
+    name: Packaging
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.9"
+
+      - name: Install Tox
+        run: pip install tox;
+
+      - name: Check packaging
+        run: tox -e packaging;
+
+
+  unit:
+    name: Unit Tests using Python ${{ matrix.python }} on Ubuntu
+
+    needs: [flake8, black, mypy, docs, packaging]
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy-2.7", "pypy-3.7"]
+
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install Tox
+        run: pip install tox;
+
+      - name: Run unit tests
+        shell: bash
+        # This hairy shell code is here to map the Python versions
+        # specified above to the equivalents used in Tox environments.
+        run: |
+          set -eux
+          py="${{ matrix.python }}";
+          if [[ $py =~ pypy ]]; then  # PyPy
+              py_test="pypy${py:5:1}";  # Add "pypy" prefix, select major version
+          else  # CPython
+              py_test="py${py/./}";  # Add "py" prefix, remove "."
+          fi;
+          env_test="test-${py_test},codecov";
+          echo "Test environment: ${env_test}";
+          ln -s ".tox/${env_test}" testenv;  # Fixed location for upload step below
+          tox -e "${env_test}";
+
+      # Use the latest supported Python version for combining coverage to
+      # prevent parsing errors in older versions when looking at modern code.
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+
+      - name: "Combine coverage"
+        run: |
+          set -eux
+          pip install coverage[toml];
+          coverage combine;
+          coverage xml;
+        env:
+          COVERAGE_FILE: .tox/coverage
+
+      - name: "Upload coverage to Codecov"
+        uses: "codecov/codecov-action@v1"
+        with:
+          env_vars: GITHUB_REF,GITHUB_COMMIT,GITHUB_USER,GITHUB_WORKFLOW
+          fail_ci_if_error: true
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_COMMIT: ${{ github.sha }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hyperlink Changelog
 
+## Next
+
+* CPython 3.9 added to text matrix
+
 ## 20.0.1
 
 *(August 4, 2020)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-* CPython 3.9 added to text matrix
+* CPython 3.9 added to test matrix
 
 ## 20.0.1
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: PyPy",
         "License :: OSI Approved :: MIT License",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -126,8 +126,7 @@ deps =
     pep8-naming==0.11.1
     pycodestyle==2.6.0
     pydocstyle==5.1.1
-    # pin pyflakes pending a release with https://github.com/PyCQA/pyflakes/pull/455
-    git+git://github.com/PyCQA/pyflakes@ffe9386#egg=pyflakes
+    pyflakes==2.2.0
 
 commands =
     flake8 {posargs:setup.py src/{env:PY_MODULE}}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 envlist =
     flake8, mypy, black
-    test-py{26,27,34,35,36,37,38,py2,py3}
+    test-py{26,27,34,35,36,37,38,39,py2,py3}
     coverage_report
     docs
     packaging


### PR DESCRIPTION
Travis is queuing builds for ages. 

I've also added Python 3.9 to CI and the package metadata. I notice that 2.6 isn't in CI. Should it still be listed as supported?