### PR TITLE
Remove Python 2.7 and Python 3.5 from the Windows build matrix.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,12 +6,6 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27-x64"
-      TOX_ENV: "test-py27,codecov"
-
-    - PYTHON: "C:\\Python35-x64"
-      TOX_ENV: "test-py35,codecov"
-
     - PYTHON: "C:\\Python36-x64"
       TOX_ENV: "test-py36,codecov"
 


### PR DESCRIPTION
These builds are not working any more and are blocking any other PR from passing CI.