### PR TITLE
Check whether an EncodedURL can be decoded before giving it back

### DIFF
--- a/src/hyperlink/hypothesis.py
+++ b/src/hyperlink/hypothesis.py
@@ -31,7 +31,7 @@ else:
 
     from . import DecodedURL, EncodedURL
 
-    from hypothesis import assume
+    from hypothesis import reject
     from hypothesis.strategies import (
         composite,
         integers,
@@ -137,7 +137,7 @@ else:
         try:
             idna_encode(result)
         except IDNAError:
-            assume(False)
+            reject()
 
         return result
 
@@ -198,7 +198,7 @@ else:
         try:
             check_label(label)
         except UnicodeError:  # pragma: no cover (not always drawn)
-            assume(False)
+            reject()
 
         return label
 
@@ -322,4 +322,4 @@ else:
         try:
             return DecodedURL(encoded_url)
         except UnicodeDecodeError:
-            assume(False)
+            reject()

--- a/src/hyperlink/hypothesis.py
+++ b/src/hyperlink/hypothesis.py
@@ -318,4 +318,8 @@ else:
         Call the L{EncodedURL.to_uri} method on each URL to get an HTTP
         protocol-friendly URI.
         """
-        return DecodedURL(draw(encoded_urls()))
+        encoded_url = draw(encoded_urls())
+        try:
+            return DecodedURL(encoded_url)
+        except:
+            assume(False)

--- a/src/hyperlink/hypothesis.py
+++ b/src/hyperlink/hypothesis.py
@@ -321,5 +321,5 @@ else:
         encoded_url = draw(encoded_urls())
         try:
             return DecodedURL(encoded_url)
-        except:
+        except UnicodeDecodeError:
             assume(False)

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,15 @@ basepython = {[default]basepython}
 skip_install = True
 
 deps =
+    # Pin black and all of its dependencies so an incompatible release of one
+    # of them doesn't break this environment.
+    appdirs==1.4.4
     black==21.7b0
+    click==7.1.2
+    mypy-extensions==0.4.3
+    pathspec==0.9.0
+    regex==2022.8.17
+    tomli==1.2.3
 
 setenv =
     BLACK_LINT_ARGS=--check


### PR DESCRIPTION
This fixes #153 by fixing _only_ the Hypothesis strategy for `DecodedURL`.  It doesn't stop `encoded_urls` from finding `EncodedURL` values which cannot be decoded by `DecodedURL`.  It only catches these values in the `decoded_urls` strategy.

This might be the wrong change to make since it really only _hides_ the fact that not all `EncodedURL` values can be decoded with `DecodedURL`.  It seems like fixing the actual decoding in `DecodedURL` would be better, but I'm not sure how to do that.
