### PR TITLE
Do not IDNA-encode IPv6 literal hosts in to_uri() (#188)

### DIFF
--- a/src/hyperlink/_url.py
+++ b/src/hyperlink/_url.py
@@ -1667,11 +1667,16 @@ class URL(object):
         new_path = _encode_path_parts(
             self.path, has_scheme=bool(self.scheme), rooted=False, maximal=True
         )
-        new_host = (
-            self.host
-            if not self.host
-            else idna_encode(self.host, uts46=True).decode("ascii")
-        )
+        family, host_text = parse_host(self.host)
+        if family is not None:
+            # IPv4 / IPv6 literal
+            new_host = host_text
+        else:
+            new_host = (
+                self.host
+                if not self.host
+                else idna_encode(self.host, uts46=True).decode("ascii")
+            )
         return self.replace(
             userinfo=new_userinfo,
             host=new_host,

--- a/src/hyperlink/test/test_hypothesis.py
+++ b/src/hyperlink/test/test_hypothesis.py
@@ -18,7 +18,7 @@ else:
     except ImportError:
         from mock import patch  # type: ignore[misc]
 
-    from hypothesis import given, settings
+    from hypothesis import given, settings, HealthCheck
     from hypothesis.strategies import SearchStrategy, data
 
     from idna import IDNAError, check_label, encode as idna_encode
@@ -174,6 +174,7 @@ else:
                 )
 
         @given(hostnames(allow_leading_digit=False, allow_idn=False))
+        @settings(suppress_health_check=[HealthCheck.filter_too_much])
         def test_hostnames_ascii_nolead(self, hostname):
             # type: (Text) -> None
             """

--- a/src/hyperlink/test/test_parse.py
+++ b/src/hyperlink/test/test_parse.py
@@ -35,3 +35,8 @@ class TestURL(HyperlinkTestCase):
 
         with self.assertRaises(UnicodeDecodeError):
             purl3.fragment
+
+    def test_ipv6_literal_not_idna_encoded(self) -> None:
+
+        url = EncodedURL.from_text("http://[::1]:8080/path")
+        assert url.to_uri().to_text() == "http://[::1]:8080/path"

--- a/tox.ini
+++ b/tox.ini
@@ -94,6 +94,7 @@ skip_install = True
 
 deps =
     black==21.7b0
+    click<8.0
 
 setenv =
     BLACK_LINT_ARGS=--check


### PR DESCRIPTION
### Summary

This PR fixes a long-standing bug in `hyperlink.URL.to_uri()` where plain IPv6 literal hosts (e.g., [::1]) are incorrectly passed to `idna.encode()`.

This bug was originally reported in #68 and #188 and affects downstream users (e.g., treq) even on current releases.